### PR TITLE
AMF Crash Fix:

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -623,6 +623,7 @@ func (ue *AmfUe) ClearRegistrationRequestData(accessType models.AccessType) {
 //this method called when we are reusing the same uecontext during the registration procedure
 func (ue *AmfUe) ClearRegistrationData() {
 	//Allowed Nssai should be cleared first as it is a new Registration
+	ue.SubscribedNssai = nil
 	ue.AllowedNssai = make(map[models.AccessType][]models.AllowedSnssai)
 
 	//Clearing SMContextList locally

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -667,8 +667,12 @@ func HandleInitialRegistration(ue *context.AmfUe, anType models.AccessType) erro
 	problemDetails, err := consumer.AMPolicyControlCreate(ue, anType)
 	if problemDetails != nil {
 		ue.GmmLog.Errorf("AM Policy Control Create Failed Problem[%+v]", problemDetails)
+		gmm_message.SendRegistrationReject(ue.RanUe[anType], nasMessage.Cause5GMM5GSServicesNotAllowed, "")
+		return fmt.Errorf("AMPolicy Control Create failed at PCF")
 	} else if err != nil {
 		ue.GmmLog.Errorf("AM Policy Control Create Error[%+v]", err)
+		gmm_message.SendRegistrationReject(ue.RanUe[anType], nasMessage.Cause5GMM5GSServicesNotAllowed, "")
+		return err
 	}
 
 	// Service Area Restriction are applicable only to 3GPP access

--- a/gmm/message/send.go
+++ b/gmm/message/send.go
@@ -208,6 +208,9 @@ func SendSecurityModeCommand(ue *context.RanUe, eapSuccess bool, eapMessage stri
 func SendDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrationRequired bool, cause5GMM uint8) {
 	ue.AmfUe.GmmLog.Info("Send Deregistration Request")
 
+	//setting accesstype
+	ue.AmfUe.DeregistrationTargetAccessType = accessType
+
 	nasMsg, err := BuildDeregistrationRequest(ue, accessType, reRegistrationRequired, cause5GMM)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())


### PR DESCRIPTION
Amf crashed during registration when it triggers after nw intiated deregister
issue due to stale ue context present during registration, However
registration should pass and amf should do context replacement.
AMF is not clearing Subscribed Nssai List during registration, so it
to use older subscribed nssai which leads to crash in AMF.