### PR TITLE
REST API_PURGE UE CONTEXT

### DIFF
--- a/gmm/mock_gmm.go
+++ b/gmm/mock_gmm.go
@@ -6,11 +6,18 @@ import (
 	"github.com/omec-project/fsm"
 )
 
+var MockRegisteredCallCount uint32 = 0
+var MockDeregisteredInitiatedCallCount uint32 = 0
+var MockContextSetupCallCount uint32 = 0
+var MockDeRegisteredCallCount uint32 = 0
+var MockSecurityModeCallCount uint32 = 0
+var MockAuthenticationCallCount uint32 = 0
+
 var mockCallbacks = fsm.Callbacks{
-	context.Deregistered:            DeRegistered,
-	context.Authentication:          Authentication,
-	context.SecurityMode:            SecurityMode,
-	context.ContextSetup:            ContextSetup,
+	context.Deregistered:            MockDeRegistered,
+	context.Authentication:          MockAuthentication,
+	context.SecurityMode:            MockSecurityMode,
+	context.ContextSetup:            MockContextSetup,
 	context.Registered:              MockRegistered,
 	context.DeregistrationInitiated: MockDeregisteredInitiated,
 }
@@ -23,12 +30,36 @@ func Mockinit() {
 	}
 }
 
+func MockDeRegistered(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockDeRegistered")
+	MockDeRegisteredCallCount++
+}
+
+func MockAuthentication(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockAuthentication")
+	MockAuthenticationCallCount++
+}
+
+func MockSecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockSecurityMode")
+	MockSecurityModeCallCount++
+}
+
+func MockContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockContextSetup")
+	MockContextSetupCallCount++
+}
+
 func MockRegistered(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info(event)
 	logger.GmmLog.Info("MockRegistered")
+	MockRegisteredCallCount++
 }
 
 func MockDeregisteredInitiated(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	logger.GmmLog.Info("MockDeregisteredInitiated")
+	MockDeregisteredInitiatedCallCount++
+
 	amfUe := args[ArgAmfUe].(*context.AmfUe)
 	amfUe.Remove()
 }

--- a/gmm/mock_gmm.go
+++ b/gmm/mock_gmm.go
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2022 Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 package gmm
 
 import (

--- a/gmm/mock_gmm.go
+++ b/gmm/mock_gmm.go
@@ -1,0 +1,34 @@
+package gmm
+
+import (
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/fsm"
+)
+
+var mockCallbacks = fsm.Callbacks{
+	context.Deregistered:            DeRegistered,
+	context.Authentication:          Authentication,
+	context.SecurityMode:            SecurityMode,
+	context.ContextSetup:            ContextSetup,
+	context.Registered:              MockRegistered,
+	context.DeregistrationInitiated: MockDeregisteredInitiated,
+}
+
+func Mockinit() {
+	if f, err := fsm.NewFSM(transitions, mockCallbacks); err != nil {
+		logger.GmmLog.Errorf("Initialize Gmm FSM Error: %+v", err)
+	} else {
+		GmmFSM = f
+	}
+}
+
+func MockRegistered(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockRegistered")
+}
+
+func MockDeregisteredInitiated(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
+	logger.GmmLog.Info("MockDeregisteredInitiated")
+	amfUe := args[ArgAmfUe].(*context.AmfUe)
+	amfUe.Remove()
+}

--- a/oam/api_purge_ue_context.go
+++ b/oam/api_purge_ue_context.go
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2022 Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 package oam
 
 import (

--- a/oam/api_purge_ue_context.go
+++ b/oam/api_purge_ue_context.go
@@ -1,0 +1,42 @@
+package oam
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/producer"
+	"github.com/omec-project/http_wrapper"
+
+	"github.com/omec-project/openapi/models"
+)
+
+func HTTPPurgeUEContext(c *gin.Context) {
+	setCorsHeader(c)
+
+	amfSelf := context.AMF_Self()
+	req := http_wrapper.NewRequest(c.Request, nil)
+	if supi, exists := c.Params.Get("supi"); exists {
+		req.Params["supi"] = supi
+		reqUri := req.URL.RequestURI()
+		if ue, ok := amfSelf.AmfUeFindBySupi(supi); ok {
+			sbiMsg := context.SbiMsg{
+				UeContextId: ue.Supi,
+				ReqUri:      reqUri,
+				Msg:         nil,
+				Result:      make(chan context.SbiResponseMsg, 10),
+			}
+			ue.EventChannel.UpdateSbiHandler(producer.HandleOAMPurgeUEContextRequest)
+			ue.EventChannel.SubmitMessage(sbiMsg)
+			msg := <-sbiMsg.Result
+			if msg.ProblemDetails != nil {
+				c.JSON(int(msg.ProblemDetails.(models.ProblemDetails).Status), msg.ProblemDetails)
+			} else {
+				c.JSON(http.StatusOK, nil)
+			}
+		} else {
+			c.JSON(http.StatusOK, nil)
+		}
+	}
+}

--- a/oam/api_purge_ue_context.go
+++ b/oam/api_purge_ue_context.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
 	"github.com/omec-project/http_wrapper"
 
@@ -36,7 +37,8 @@ func HTTPPurgeUEContext(c *gin.Context) {
 				c.JSON(http.StatusOK, nil)
 			}
 		} else {
-			c.JSON(http.StatusOK, nil)
+			logger.ProducerLog.Errorln("No Ue found by the provided supi")
+			c.JSON(http.StatusNotFound, nil)
 		}
 	}
 }

--- a/oam/routers.go
+++ b/oam/routers.go
@@ -7,6 +7,7 @@ package oam
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -54,6 +55,8 @@ func AddService(engine *gin.Engine) *gin.RouterGroup {
 		switch route.Method {
 		case "GET":
 			group.GET(route.Pattern, route.HandlerFunc)
+		case "DELETE":
+			group.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
 	return group
@@ -83,5 +86,12 @@ var routes = Routes{
 		"GET",
 		"/registered-ue-context/:supi",
 		HTTPRegisteredUEContext,
+	},
+
+	{
+		"Purge UE Context",
+		strings.ToUpper("Delete"),
+		"/purge-ue-context/:supi",
+		HTTPPurgeUEContext,
 	},
 }

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -6,11 +6,14 @@
 package producer
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/gmm"
 	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/fsm"
 	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 )
@@ -38,6 +41,25 @@ type UEContext struct {
 }
 
 type UEContexts []UEContext
+
+func HandleOAMPurgeUEContextRequest(supi, reqUri string, msg interface{}) (interface{}, string, interface{}, interface{}) {
+	amfSelf := context.AMF_Self()
+	if ue, ok := amfSelf.AmfUeFindBySupi(supi); ok {
+		ueFsmState := ue.State[models.AccessType__3_GPP_ACCESS].Current()
+		switch ueFsmState {
+		case context.Deregistered:
+			logger.ProducerLog.Infof("Removing the UE : ", fmt.Sprintf(ue.Supi))
+			ue.Remove()
+		case context.Registered:
+			logger.ProducerLog.Infof("Deregistration triggered for the UE : ", ue.Supi)
+			gmm.GmmFSM.SendEvent(ue.State[models.AccessType__3_GPP_ACCESS], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
+				gmm.ArgAmfUe:      ue,
+				gmm.ArgAccessType: models.AccessType__3_GPP_ACCESS,
+			})
+		}
+	}
+	return nil, "", nil, nil
+}
 
 func HandleOAMRegisteredUEContext(request *http_wrapper.Request) *http_wrapper.Response {
 	logger.ProducerLog.Infof("[OAM] Handle Registered UE Context")

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -48,10 +48,10 @@ func HandleOAMPurgeUEContextRequest(supi, reqUri string, msg interface{}) (inter
 		ueFsmState := ue.State[models.AccessType__3_GPP_ACCESS].Current()
 		switch ueFsmState {
 		case context.Deregistered:
-			logger.ProducerLog.Infof("Removing the UE : ", fmt.Sprintf(ue.Supi))
+			logger.ProducerLog.Info("Removing the UE : ", fmt.Sprintf(ue.Supi))
 			ue.Remove()
 		case context.Registered:
-			logger.ProducerLog.Infof("Deregistration triggered for the UE : ", ue.Supi)
+			logger.ProducerLog.Info("Deregistration triggered for the UE : ", ue.Supi)
 			gmm.GmmFSM.SendEvent(ue.State[models.AccessType__3_GPP_ACCESS], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
 				gmm.ArgAmfUe:      ue,
 				gmm.ArgAccessType: models.AccessType__3_GPP_ACCESS,

--- a/producer/oam_test.go
+++ b/producer/oam_test.go
@@ -1,0 +1,50 @@
+package producer
+
+import (
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/factory"
+	"github.com/omec-project/amf/gmm"
+	"github.com/omec-project/amf/util"
+	"github.com/omec-project/fsm"
+	"github.com/omec-project/openapi/models"
+	"testing"
+)
+
+type TestCases struct {
+	amfContext         context.AMFContext
+	amfue              context.AmfUe
+	expectedUeFsmState string
+	description        string
+}
+
+func init() {
+	factory.InitConfigFactory("../amfTest/amfcfg.yaml")
+
+	self := context.AMF_Self()
+	util.InitAmfContext(self)
+
+	gmm.Mockinit()
+}
+
+func TestHandleOAMPurgeUEContextRequest_UEDeregistered(t *testing.T) {
+	self := context.AMF_Self()
+	amfUe := self.NewAmfUe("imsi-208930100007497")
+
+	HandleOAMPurgeUEContextRequest(amfUe.Supi, "", nil)
+
+	if _, ok := self.AmfUeFindBySupi(amfUe.Supi); ok {
+		t.Errorf("test failed")
+	}
+}
+
+func TestHandleOAMPurgeUEContextRequest_UERegistered(t *testing.T) {
+	self := context.AMF_Self()
+	amfUe := self.NewAmfUe("imsi-208930100007497")
+	amfUe.State[models.AccessType__3_GPP_ACCESS] = fsm.NewState(context.Registered)
+
+	HandleOAMPurgeUEContextRequest(amfUe.Supi, "", nil)
+
+	if _, ok := self.AmfUeFindBySupi(amfUe.Supi); ok {
+		t.Errorf("test failed")
+	}
+}

--- a/producer/oam_test.go
+++ b/producer/oam_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omec-project/amf/util"
 	"github.com/omec-project/fsm"
 	"github.com/omec-project/openapi/models"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -35,6 +36,9 @@ func TestHandleOAMPurgeUEContextRequest_UEDeregistered(t *testing.T) {
 	if _, ok := self.AmfUeFindBySupi(amfUe.Supi); ok {
 		t.Errorf("test failed")
 	}
+
+	assert.Equal(t, uint32(0), gmm.MockDeregisteredInitiatedCallCount)
+	assert.Equal(t, uint32(0), gmm.MockRegisteredCallCount)
 }
 
 func TestHandleOAMPurgeUEContextRequest_UERegistered(t *testing.T) {
@@ -47,4 +51,7 @@ func TestHandleOAMPurgeUEContextRequest_UERegistered(t *testing.T) {
 	if _, ok := self.AmfUeFindBySupi(amfUe.Supi); ok {
 		t.Errorf("test failed")
 	}
+
+	assert.Equal(t, uint32(2), gmm.MockRegisteredCallCount)
+	assert.Equal(t, uint32(1), gmm.MockDeregisteredInitiatedCallCount)
 }

--- a/producer/oam_test.go
+++ b/producer/oam_test.go
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2022 Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 package producer
 
 import (
+	"testing"
+
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/factory"
 	"github.com/omec-project/amf/gmm"
@@ -8,7 +15,6 @@ import (
 	"github.com/omec-project/fsm"
 	"github.com/omec-project/openapi/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type TestCases struct {


### PR DESCRIPTION
This PR implements a REST API for purging the UE context. If the UE is in registered state, Network Initiated deregistration is triggered. Else, UE is directly removed. PFA for logs.
[amf.txt](https://github.com/omec-project/amf/files/8915724/amf.txt)
[gnbsim.txt](https://github.com/omec-project/amf/files/8915728/gnbsim.txt)
