### PR TITLE
fix: Update commit hash for nas package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4
 github.com/omec-project/logger_util v1.0.100-dev/go.mod h1:UkD09amIhlh8P0k82A6Uz/atiZGeFS3C2wd334CKpuY=
 github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFNBx41g630Q=
 github.com/omec-project/logger_util v1.1.0/go.mod h1:UkD09amIhlh8P0k82A6Uz/atiZGeFS3C2wd334CKpuY=
-github.com/omec-project/nas v1.1.1 h1:NY54Flhh2SDfP/BYuKQsYp4QJElvy3xzCLjIJ1b9T2c=
-github.com/omec-project/nas v1.1.1/go.mod h1:WRl/gOe8pZATzTk5pHbAcqUuWbmLdVV/jzjnl5lCcJ8=
+github.com/omec-project/nas v1.1.1 h1:NQ3Xa4n5RKWfy6Igh+nTjSkFz723tyX4At6I+e2Uzjg=
+github.com/omec-project/nas v1.1.1/go.mod h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
 github.com/omec-project/ngap v1.1.0 h1:J9bkPEzzyGd1787nGY/aZVp3gckkZBoJB4tkTo59eyw=
 github.com/omec-project/ngap v1.1.0/go.mod h1:A+T3+JKk+6AuhnMr6W319Tc7E176ig6rIRDVSKQ7E5g=
 github.com/omec-project/openapi v1.0.100-dev/go.mod h1:Fv9ajWROYypcNER+ZwWXPhLCdV4pBz75KqFp/R/2gCw=


### PR DESCRIPTION
This PR holds changes to fix the following error which was occurring while building AMF,

```
verifying github.com/omec-project/nas@v1.1.1/go.mod: checksum mismatch
	downloaded: h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
	go.sum:     h1:WRl/gOe8pZATzTk5pHbAcqUuWbmLdVV/jzjnl5lCcJ8=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'
```