### PR TITLE
Fix readbuffer size in AMF.

### DIFF
--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -24,7 +24,7 @@ type NGAPHandler struct {
 	HandleNotification func(conn net.Conn, notification sctp.Notification)
 }
 
-const readBufSize uint32 = 8192
+const readBufSize uint32 = 131072
 
 // set default read timeout to 2 seconds
 var readTimeout syscall.Timeval = syscall.Timeval{Sec: 2, Usec: 0}


### PR DESCRIPTION
Keeping it just 8k causes lot of message drop at the socket level.