### PR TITLE
Set a timeout for NSSF Selection

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -260,7 +260,7 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 // toBeSwitch -> Xn Handover to request to switch the PDU session to a new downlink N3 tunnel endpoint
 // failedToBeSwitch -> indicate that the PDU session failed to be setup in the target RAN
 // targetId, targetServingNfId(preparation with AMF change) -> N2 handover
-// release -> duplicated PDU Session Id in subclause 5.2.2.3.11, slice not available in subclause 5.2.2.3.12
+// release -> duplicated PDU Session Id in TS 29.502 subclause 5.2.2.3.11, slice not available in TS 29.502 subclause 5.2.2.3.12
 // ngApCause -> e.g. the NGAP cause for requesting to deactivate the user plane connection of the PDU session.
 // 5gMmCauseValue -> AMF received a 5GMM cause code from the UE e.g 5GMM Status message in response to
 // a Downlink NAS Transport message carrying 5GSM payload

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -94,14 +94,21 @@ func SelectSmf(
 	nsiInformation := ue.GetNsiInformationFromSnssai(anType, snssai)
 	if nsiInformation == nil {
 		if ue.NssfUri == "" {
-			// TODO: Set a timeout of NSSF Selection or will starvation here
+			ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+			defer cancel()
 			for {
-				if err := SearchNssfNSSelectionInstance(ue, nrfUri, models.NfType_NSSF,
-					models.NfType_AMF, nil); err != nil {
-					ue.GmmLog.Errorf("AMF can not select an NSSF Instance by NRF[Error: %+v]", err)
-					time.Sleep(2 * time.Second)
-				} else {
-					break
+				select{
+				case <-ctx.Done():
+					ue.GmmLog.Errorf("NSSF Selection Timed Out: %v", ctx.Err())
+					return
+				default:
+					if err := SearchNssfNSSelectionInstance(ue, nrfUri, models.NfType_NSSF,
+						models.NfType_AMF, nil); err != nil{
+						ue.GmmLog.Errorf("AMF can not select an NSSF Instance by NRF[Error: %+v]", err)
+						time.Sleep(2 * time.Second)
+					} else{
+						return
+					}
 				}
 			}
 		}


### PR DESCRIPTION
1. Add Technical Specification(TS) Reference in the comment.

2. Complete a [TODO task]( https://github.com/omec-project/amf/blob/master/consumer/sm_context.go#L97), which tells to **Set a timeout of NSSF Selection or will starvation here**.

Signed-off-by: Shubham Kumar [shubham.kumar@ramanujan.du.ac.in](mailto:shubham.kumar@ramanujan.du.ac.in)