### PR TITLE
fix: doesnt return when network slice is nil

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -630,9 +630,6 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 		logger.GrpcLog.Infof("Received updateConfig in the amf app : %v", rsp)
 		var tai []models.Tai
 		var plmnList []*factory.PlmnSupportItem
-		if rsp.NetworkSlice == nil {
-			return false
-		}
 		for _, ns := range rsp.NetworkSlice {
 			var snssai *models.Snssai
 			logger.GrpcLog.Infoln("Network Slice Name ", ns.Name)
@@ -682,7 +679,7 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 				}
 
 			}
-		} // end of network slice for loop
+		}
 
 		//Update PlmnSupportList/ServedGuamiList/ServedTAIList in Amf Config
 		//factory.AmfConfig.Configuration.ServedGumaiList = nil
@@ -695,7 +692,6 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 }
 
 func (amf *AMF) SendNFProfileUpdateToNrf() {
-	//for rocUpdateConfig := range RocUpdateConfigChannel {
 	for rocUpdateConfig := range RocUpdateConfigChannel {
 		if rocUpdateConfig {
 			self := context.AMF_Self()


### PR DESCRIPTION
## Description

This PR revers one change added in commit https://github.com/omec-project/amf/commit/3b7558f03d8388b4aac65f27a1d26f93e58e9de7. This issue was that `func UpdateConfig` would return if 1 of the commChannel message contained a nil network slice instead of continuously running.

Fixes #134 