### PR TITLE
fix: Removes stop of UpdateConfig channel loop when 1 item has no network slice

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -621,9 +621,6 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 	for rsp := range commChannel {
 		logger.GrpcLog.Infof("Received updateConfig in the amf app : %v", rsp)
 		var tai []models.Tai
-		if rsp.NetworkSlice == nil {
-			return false
-		}
 		for _, ns := range rsp.NetworkSlice {
 			var snssai *models.Snssai
 			logger.GrpcLog.Infoln("Network Slice Name ", ns.Name)
@@ -671,7 +668,7 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 					logger.GrpcLog.Infoln("Plmn not present in the message ")
 				}
 			}
-		} // end of network slice for loop
+		}
 
 		// Update PlmnSupportList/ServedGuamiList/ServedTAIList in Amf Config
 		// factory.AmfConfig.Configuration.ServedGumaiList = nil

--- a/service/init.go
+++ b/service/init.go
@@ -621,7 +621,6 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 	for rsp := range commChannel {
 		logger.GrpcLog.Infof("Received updateConfig in the amf app : %v", rsp)
 		var tai []models.Tai
-		var plmnList []*factory.PlmnSupportItem
 		if rsp.NetworkSlice == nil {
 			return false
 		}
@@ -652,7 +651,6 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 					logger.GrpcLog.Infoln("Plmn mcc ", site.Plmn.Mcc)
 					plmn.PlmnId.Mnc = site.Plmn.Mnc
 					plmn.PlmnId.Mcc = site.Plmn.Mcc
-					plmnList = append(plmnList, plmn)
 
 					if ns.Nssai != nil {
 						plmn.SNssaiList = append(plmn.SNssaiList, *snssai)


### PR DESCRIPTION
## Description

This PR fixes an issue introduced in commit https://github.com/omec-project/amf/commit/3b7558f03d8388b4aac65f27a1d26f93e58e9de7 where the `UpdateConfig` would return early instead of continuously looking for new messages in the channel.

Fixes #134 