### PR TITLE
fix: fetches nssf uri even if already cached

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -92,16 +92,14 @@ func SelectSmf(
 
 	nsiInformation := ue.GetNsiInformationFromSnssai(anType, snssai)
 	if nsiInformation == nil {
-		if ue.NssfUri == "" {
-			// TODO: Set a timeout of NSSF Selection or will starvation here
-			for {
-				if err := SearchNssfNSSelectionInstance(ue, nrfUri, models.NfType_NSSF,
-					models.NfType_AMF, nil); err != nil {
-					ue.GmmLog.Errorf("AMF can not select an NSSF Instance by NRF[Error: %+v]", err)
-					time.Sleep(2 * time.Second)
-				} else {
-					break
-				}
+		// TODO: Set a timeout of NSSF Selection or will starvation here
+		for {
+			if err := SearchNssfNSSelectionInstance(ue, nrfUri, models.NfType_NSSF,
+				models.NfType_AMF, nil); err != nil {
+				ue.GmmLog.Errorf("AMF can not select an NSSF Instance by NRF[Error: %+v]", err)
+				time.Sleep(2 * time.Second)
+			} else {
+				break
 			}
 		}
 


### PR DESCRIPTION
## Description

This PR makes it so that  the `SelectSmf` function retrieves `SearchNssfNSSelectionInstance` even if there already is a stored value for the NSSF URI. This fixes an issue where the NSSF uri was only stored once on AMF startup and never retrieved again. This was a problem in cases where the NSSF crashed and its IP changed.

Fixes #133 