### PR TITLE
fix: Reenable nakedret linter and fix found issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -258,7 +258,7 @@ linters:
     # - maligned
     # - nestif
     # - gomodguard
-    # - nakedret
+    - nakedret
     - gci
     - misspell
     - gofumpt

--- a/consumer/am_policy.go
+++ b/consumer/am_policy.go
@@ -110,11 +110,11 @@ func AMPolicyControlUpdate(ue *amf_context.AmfUe, updateRequest models.PolicyAss
 			// TODO: Presence Reporting Area handling (TS 23.503 6.1.2.5, TS 23.501 5.6.11)
 			// }
 		}
-		return
+		return problemDetails, err
 	} else if httpResp != nil {
 		if httpResp.Status != localErr.Error() {
 			err = localErr
-			return
+			return problemDetails, err
 		}
 		problem := localErr.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails)
 		problemDetails = &problem

--- a/consumer/communication.go
+++ b/consumer/communication.go
@@ -179,11 +179,11 @@ func ReleaseUEContextRequest(ue *amf_context.AmfUe, ngapCause models.NgApCause) 
 	httpResp, localErr := client.IndividualUeContextDocumentApi.ReleaseUEContext(
 		ctx, ueContextId, ueContextRelease)
 	if localErr == nil {
-		return
+		return problemDetails, err
 	} else if httpResp != nil {
 		if httpResp.Status != localErr.Error() {
 			err = localErr
-			return
+			return problemDetails, err
 		}
 		problem := localErr.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails)
 		problemDetails = &problem
@@ -233,7 +233,7 @@ func UEContextTransferRequest(
 	} else if httpResp != nil {
 		if httpResp.Status != localErr.Error() {
 			err = localErr
-			return
+			return ueContextTransferRspData, problemDetails, err
 		}
 		problem := localErr.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails)
 		problemDetails = &problem

--- a/consumer/nf_mangement.go
+++ b/consumer/nf_mangement.go
@@ -36,25 +36,25 @@ func BuildNFInstance(context *amf_context.AMFContext) (profile models.NfProfile,
 	amfInfo := models.AmfInfo{}
 	if len(context.ServedGuamiList) == 0 {
 		err = fmt.Errorf("Gumai List is Empty in AMF")
-		return
+		return profile, err
 	}
 	regionId, setId, _, err1 := util.SeperateAmfId(context.ServedGuamiList[0].AmfId)
 	if err1 != nil {
 		err = err1
-		return
+		return profile, err
 	}
 	amfInfo.AmfRegionId = regionId
 	amfInfo.AmfSetId = setId
 	amfInfo.GuamiList = &context.ServedGuamiList
 	if len(context.SupportTaiLists) == 0 {
 		err = fmt.Errorf("SupportTaiList is Empty in AMF")
-		return
+		return profile, err
 	}
 	amfInfo.TaiList = &context.SupportTaiLists
 	profile.AmfInfo = &amfInfo
 	if context.RegisterIPv4 == "" {
 		err = fmt.Errorf("AMF Address is empty")
-		return
+		return profile, err
 	}
 	profile.Ipv4Addresses = append(profile.Ipv4Addresses, context.RegisterIPv4)
 	service := []models.NfService{}

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -190,7 +190,7 @@ func SendCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.Sm
 	} else if httpResponse != nil {
 		if httpResponse.Status != err.Error() {
 			err1 = err
-			return
+			return response, smContextRef, errorResponse, problemDetail, err1
 		}
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503, 504:
@@ -509,7 +509,7 @@ func SendUpdateSmContextRequest(smContext *amf_context.SmContext,
 	} else if httpResponse != nil {
 		if httpResponse.Status != err.Error() {
 			err1 = err
-			return
+			return response, errorResponse, problemDetail, err1
 		}
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503:

--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -180,7 +180,7 @@ func SDMGetSliceSelectionSubscriptionData(ue *amf_context.AmfUe) (problemDetails
 	} else if httpResp != nil {
 		if httpResp.Status != localErr.Error() {
 			err = localErr
-			return
+			return problemDetails, err
 		}
 		problem := localErr.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails)
 		problemDetails = &problem

--- a/consumer/ue_authentication.go
+++ b/consumer/ue_authentication.go
@@ -137,7 +137,7 @@ func SendEapAuthConfirmRequest(ue *amf_context.AmfUe, eapMsg nasType.EAPMessage)
 	} else if httpResponse != nil {
 		if httpResponse.Status != err.Error() {
 			err1 = err
-			return
+			return response, problemDetails, err1
 		}
 		switch httpResponse.StatusCode {
 		case 400, 500:


### PR DESCRIPTION
Re-enables the `nakedret` linter and fix the issues found by it. This PR only makes the current implicit behaviour explicit to satisfy the linter. It does not change any current behaviors.