### PR TITLE
Fix NudmSDM url after udm crash

### DIFF
--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -185,7 +185,7 @@ func SDMGetSliceSelectionSubscriptionData(ue *amf_context.AmfUe) (problemDetails
 		problem := localErr.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails)
 		problemDetails = &problem
 	} else {
-		err = openapi.ReportError("server no response")
+		err = openapi.ReportError("Could not contact UDM at %v, %+v", ue.NudmSDMUri, localErr)
 	}
 	return problemDetails, err
 }

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1173,18 +1173,16 @@ func communicateWithUDM(ue *context.AmfUe, accessType models.AccessType) error {
 
 func getSubscribedNssai(ue *context.AmfUe) {
 	amfSelf := context.AMF_Self()
-	if ue.NudmSDMUri == "" {
-		param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
-			Supi: optional.NewString(ue.Supi),
-		}
-		for {
-			err := consumer.SearchUdmSdmInstance(ue, amfSelf.NrfUri, models.NfType_UDM, models.NfType_AMF, &param)
-			if err != nil {
-				ue.GmmLog.Errorf("AMF can not select an Nudm_SDM Instance by NRF[Error: %+v]", err)
-				time.Sleep(2 * time.Second)
-			} else {
-				break
-			}
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		Supi: optional.NewString(ue.Supi),
+	}
+	for {
+		err := consumer.SearchUdmSdmInstance(ue, amfSelf.NrfUri, models.NfType_UDM, models.NfType_AMF, &param)
+		if err != nil {
+			ue.GmmLog.Errorf("AMF can not select an Nudm_SDM Instance by NRF[Error: %+v]", err)
+			time.Sleep(2 * time.Second)
+		} else {
+			break
 		}
 	}
 	problemDetails, err := consumer.SDMGetSliceSelectionSubscriptionData(ue)


### PR DESCRIPTION
Because the AMF is keeping a cache of all the UEs it sees and saves the NFs URI in it, when the UDM is restarted with a new IP for any reason, the first connection by a previously seen user would get rejected.

It is easy to test the previous error by deploying the core and gnbsim, configuring a subscriber and executing a succesful simulation. After that, deleting the UDM pod in Kubernetes and wait for the pod to be restarted properly. Run a new simulation, and it will fail. Running the simulation again after a failure will work, because it will have cleaned the cache.

This change makes it so that we always ask the NRF for the URI to use.