### PR TITLE
chore: Re-enable errcheck linter with required fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ cscope.*
 *.log
 *.pcap
 vendor*
+
+gmm/gmm.dot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -247,7 +247,6 @@ linters:
     # - structcheck
     - varcheck
     - ineffassign
-    # - deadcode
     - typecheck
     # Additional
     # - lll

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -245,7 +245,6 @@ linters:
     # - unused
     # - gosimple
     # - structcheck
-    - varcheck
     - ineffassign
     - typecheck
     # Additional

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -240,7 +240,7 @@ linters:
   enable:
     - gofmt
     # - govet
-    # - errcheck
+    - errcheck
     # - staticcheck
     # - unused
     # - gosimple

--- a/amf_test.go
+++ b/amf_test.go
@@ -26,8 +26,12 @@ import (
 var AMFTest = &service.AMF{}
 
 func init() {
-	os.Setenv("POD_IP", "127.0.0.1")
-	factory.InitConfigFactory("amfTest/amfcfg.yaml")
+	if err := os.Setenv("POD_IP", "127.0.0.1"); err != nil {
+		fmt.Printf("Could not set env POD_IP: %+v\n", err)
+	}
+	if err := factory.InitConfigFactory("amfTest/amfcfg.yaml"); err != nil {
+		fmt.Printf("Could not InitConfigFactory: %+v\n", err)
+	}
 }
 
 func GetNetworkSliceConfig() *protos.NetworkSliceResponse {

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/antihax/optional"
 	amf_context "github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/util"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/openapi"
@@ -26,10 +27,15 @@ import (
 
 func getServingSmfIndex(smfNum int) (servingSmfIndex int) {
 	servingSmfIndexStr := os.Getenv("SERVING_SMF_INDEX")
-	i, _ := strconv.Atoi(servingSmfIndexStr)
+	i, err := strconv.Atoi(servingSmfIndexStr)
+	if err != nil {
+		logger.ConsumerLog.Errorf("Could not convert %s to int: %v", servingSmfIndexStr, err)
+	}
 	servingSmfIndexInt := i + 1
 	servingSmfIndex = servingSmfIndexInt % smfNum
-	os.Setenv("SERVING_SMF_INDEX", strconv.Itoa(servingSmfIndex))
+	if err := os.Setenv("SERVING_SMF_INDEX", strconv.Itoa(servingSmfIndex)); err != nil {
+		logger.ConsumerLog.Errorf("Could not set env SERVING_SMF_INDEX: %v", err)
+	}
 	return
 }
 

--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -73,7 +73,9 @@ func (ran *AmfRan) Remove() {
 			NfStatus: mi.NfStatusDisconnected, NfName: ran.GnbId,
 		},
 	}
-	metrics.StatWriter.PublishNfStatusEvent(gnbStatus)
+	if err := metrics.StatWriter.PublishNfStatusEvent(gnbStatus); err != nil {
+		ran.Log.Errorf("Could not publish NfStatusEvent: %v", err)
+	}
 
 	ran.SetRanStats(RanDisconnected)
 	ran.Log.Infof("Remove RAN Context[ID: %+v]", ran.RanID())

--- a/context/context.go
+++ b/context/context.go
@@ -146,7 +146,9 @@ func (context *AMFContext) AllocateGutiToUe(ue *AmfUe) {
 func (context *AMFContext) ReAllocateGutiToUe(ue *AmfUe) {
 	servedGuami := context.ServedGuamiList[0]
 
-	context.Drsm.ReleaseInt32ID(ue.Tmsi)
+	if err := context.Drsm.ReleaseInt32ID(ue.Tmsi); err != nil {
+		logger.ContextLog.Errorf("Errro releasing tmsi: %v", err)
+	}
 	// tmsiGenerator.FreeID(int64(ue.Tmsi))
 
 	ue.Tmsi = context.TmsiAllocate()
@@ -168,7 +170,10 @@ func (context *AMFContext) AllocateRegistrationArea(ue *AmfUe, anType models.Acc
 	taiList := make([]models.Tai, len(context.SupportTaiLists))
 	copy(taiList, context.SupportTaiLists)
 	for i := range taiList {
-		tmp, _ := strconv.ParseUint(taiList[i].Tac, 10, 32)
+		tmp, err := strconv.ParseUint(taiList[i].Tac, 10, 32)
+		if err != nil {
+			logger.ContextLog.Errorf("Could not convert TAC to int: %v", err)
+		}
 		taiList[i].Tac = fmt.Sprintf("%06x", tmp)
 		logger.ContextLog.Infof("Supported Tai List in AMF Plmn: %v, Tac: %v", taiList[i].PlmnId, taiList[i].Tac)
 	}
@@ -209,7 +214,9 @@ func (context *AMFContext) DeleteAMFStatusSubscription(subscriptionID string) {
 		logger.ContextLog.Error(err)
 	} else {
 		// amfStatusSubscriptionIDGenerator.FreeID(id)
-		context.Drsm.ReleaseInt32ID(int32(id))
+		if err := context.Drsm.ReleaseInt32ID(int32(id)); err != nil {
+			logger.ContextLog.Error(err)
+		}
 	}
 }
 
@@ -431,7 +438,10 @@ func (context *AMFContext) InPlmnSupportList(snssai models.Snssai) bool {
 }
 
 func mapToByte(data map[string]interface{}) (ret []byte) {
-	ret, _ = json.Marshal(data)
+	ret, err := json.Marshal(data)
+	if err != nil {
+		logger.ContextLog.Error(err)
+	}
 	return
 }
 

--- a/context/ran_ue.go
+++ b/context/ran_ue.go
@@ -106,7 +106,9 @@ func (ranUe *RanUe) Remove() error {
 	self := AMF_Self()
 	self.RanUePool.Delete(ranUe.AmfUeNgapId)
 	// amfUeNGAPIDGenerator.FreeID(ranUe.AmfUeNgapId)
-	self.Drsm.ReleaseInt32ID(int32(ranUe.AmfUeNgapId))
+	if err := self.Drsm.ReleaseInt32ID(int32(ranUe.AmfUeNgapId)); err != nil {
+		logger.ContextLog.Errorf("Error releasing UE: %v", err)
+	}
 	return nil
 }
 
@@ -243,7 +245,10 @@ func (ranUe *RanUe) UpdateLocation(userLocationInformation *ngapType.UserLocatio
 		ranUe.Location.N3gaLocation.PortNumber = ngapConvert.PortNumberToInt(port)
 		// N3GPP TAI is operator-specific
 		// TODO: define N3GPP TAI
-		tmp, _ := strconv.ParseUint(amfSelf.SupportTaiLists[0].Tac, 10, 32)
+		tmp, err := strconv.ParseUint(amfSelf.SupportTaiLists[0].Tac, 10, 32)
+		if err != nil {
+			logger.ContextLog.Errorf("Error parsing TAC: %v", err)
+		}
 		tac := fmt.Sprintf("%06x", tmp)
 		ranUe.Location.N3gaLocation.N3gppTai = &models.Tai{
 			PlmnId: amfSelf.SupportTaiLists[0].PlmnId,

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -122,7 +122,9 @@ func transport5GSMMessage(ue *context.AmfUe, anType models.AccessType,
 
 		if !smContextExist {
 			msg := new(nas.Message)
-			msg.PlainNasDecode(&smMessage)
+			if err := msg.PlainNasDecode(&smMessage); err != nil {
+				ue.GmmLog.Errorf("Could not decode Nas message: %v", err)
+			}
 			if msg.GsmMessage != nil && msg.GsmMessage.Status5GSM != nil {
 				ue.GmmLog.Warningf("SmContext doesn't exist, 5GSM Status message received from UE with cause %v", msg.GsmMessage.Status5GSM.Cause5GSM)
 				return nil

--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -58,7 +58,9 @@ func DeRegistered(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	case NwInitiatedDeregistrationEvent:
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
 		accessType := args[ArgAccessType].(models.AccessType)
-		NetworkInitiatedDeregistrationProcedure(amfUe, accessType)
+		if err := NetworkInitiatedDeregistrationProcedure(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	case StartAuthEvent:
 		logger.GmmLog.Debugln(event)
 	case fsm.ExitEvent:
@@ -138,7 +140,9 @@ func Registered(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	case NwInitiatedDeregistrationEvent:
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
 		accessType := args[ArgAccessType].(models.AccessType)
-		NetworkInitiatedDeregistrationProcedure(amfUe, accessType)
+		if err := NetworkInitiatedDeregistrationProcedure(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	/*TODO */
 	case SliceInfoAddEvent:
 	case SliceInfoDeleteEvent:
@@ -222,11 +226,15 @@ func Authentication(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
 		accessType := args[ArgAccessType].(models.AccessType)
 		logger.GmmLog.Debugln(event)
-		HandleAuthenticationError(amfUe, accessType)
+		if err := HandleAuthenticationError(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	case NwInitiatedDeregistrationEvent:
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
 		accessType := args[ArgAccessType].(models.AccessType)
-		NetworkInitiatedDeregistrationProcedure(amfUe, accessType)
+		if err := NetworkInitiatedDeregistrationProcedure(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	case fsm.ExitEvent:
 		// clear authentication related data at exit
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
@@ -268,11 +276,14 @@ func SecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 			// Generate KnasEnc, KnasInt
 			amfUe.DerivateAlgKey()
 			if amfUe.CipheringAlg == security.AlgCiphering128NEA0 && amfUe.IntegrityAlg == security.AlgIntegrity128NIA0 {
-				GmmFSM.SendEvent(state, SecuritySkipEvent, fsm.ArgsType{
+				err := GmmFSM.SendEvent(state, SecuritySkipEvent, fsm.ArgsType{
 					ArgAmfUe:      amfUe,
 					ArgAccessType: accessType,
 					ArgNASMessage: amfUe.RegistrationRequest,
 				})
+				if err != nil {
+					logger.GmmLog.Errorln(err)
+				}
 			} else {
 				gmm_message.SendSecurityModeCommand(amfUe.RanUe[accessType], eapSuccess, eapMessage)
 			}
@@ -340,7 +351,9 @@ func SecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		accessType := args[ArgAccessType].(models.AccessType)
 		amfUe.T3560.Stop()
 		amfUe.T3560 = nil
-		NetworkInitiatedDeregistrationProcedure(amfUe, accessType)
+		if err := NetworkInitiatedDeregistrationProcedure(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	case SecurityModeSuccessEvent:
 		logger.GmmLog.Debugln(event)
 	case SecurityModeFailEvent:
@@ -440,7 +453,9 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		amfUe.T3550.Stop()
 		amfUe.T3550 = nil
 		amfUe.State[accessType].Set(context.Registered)
-		NetworkInitiatedDeregistrationProcedure(amfUe, accessType)
+		if err := NetworkInitiatedDeregistrationProcedure(amfUe, accessType); err != nil {
+			logger.GmmLog.Errorln(err)
+		}
 	case ContextSetupFailEvent:
 		logger.GmmLog.Debugln(event)
 	case fsm.ExitEvent:

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -71,7 +71,9 @@ func (writer Writer) PublishUeCtxtEvent(ctxt mi.CoreSubscriber, op mi.Subscriber
 		return err
 	} else {
 		logger.KafkaLog.Debugf("publishing ue context event[%s] ", msg)
-		StatWriter.SendMessage(msg)
+		if err := StatWriter.SendMessage(msg); err != nil {
+			logger.KafkaLog.Errorf("Could not publish ue context event, error [%v]", err.Error())
+		}
 	}
 	return nil
 }
@@ -102,7 +104,9 @@ func (writer Writer) PublishNfStatusEvent(msgEvent mi.MetricEvent) error {
 		return err
 	} else {
 		logger.KafkaLog.Debugf("publishing nf status event[%s] ", msg)
-		StatWriter.SendMessage(msg)
+		if err := StatWriter.SendMessage(msg); err != nil {
+			logger.KafkaLog.Errorf("Error publishing nf status event: %v", err)
+		}
 	}
 	return nil
 }

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/omec-project/amf/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -64,7 +65,9 @@ func init() {
 // InitMetrics initialises AMF stats
 func InitMetrics() {
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":9089", nil)
+	if err := http.ListenAndServe(":9089", nil); err != nil {
+		logger.InitLog.Errorf("Could not open metrics port: %v", err)
+	}
 }
 
 // IncrementNgapMsgStats increments message level stats

--- a/ngap/dispatcher.go
+++ b/ngap/dispatcher.go
@@ -66,8 +66,8 @@ func DispatchLb(sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2RanMsgChan chan *s
 		//ranUe.Log.Debugln("RanUe RanNgapId AmfNgapId: ", ranUe.RanUeNgapId, ranUe.AmfUeNgapId)
 		/* checking whether same AMF instance can handle this message */
 		/* redirect it to correct owner if required */
-		id, _ := amfSelf.Drsm.FindOwnerInt32ID(int32(ngapId.Value))
-		if id == nil {
+		id, err := amfSelf.Drsm.FindOwnerInt32ID(int32(ngapId.Value))
+		if id == nil || err != nil {
 			ran.Log.Warningf("DispatchLb, Couldn't find owner for amfUeNgapid: %v", ngapId.Value)
 		} else if id != nil && id.PodName != os.Getenv("HOSTNAME") {
 			rsp := &sdcoreAmfServer.AmfMessage{}
@@ -86,7 +86,9 @@ func DispatchLb(sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2RanMsgChan chan *s
 				ranUe.AmfUe.Remove()
 			}
 			if ranUe != nil {
-				ranUe.Remove()
+				if err := ranUe.Remove(); err != nil {
+					ran.Log.Errorf("Could not remove ranUe: %v", err)
+				}
 			}
 			return
 		} else {

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -76,10 +76,13 @@ func HandleOAMPurgeUEContextRequest(supi, reqUri string, msg interface{}) (inter
 			ue.Remove()
 		case context.Registered:
 			logger.ProducerLog.Info("Deregistration triggered for the UE : ", ue.Supi)
-			gmm.GmmFSM.SendEvent(ue.State[models.AccessType__3_GPP_ACCESS], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
+			err := gmm.GmmFSM.SendEvent(ue.State[models.AccessType__3_GPP_ACCESS], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
 				gmm.ArgAmfUe:      ue,
 				gmm.ArgAccessType: models.AccessType__3_GPP_ACCESS,
 			})
+			if err != nil {
+				logger.ProducerLog.Errorf("Error sending deregistration event: %v", err)
+			}
 		}
 	}
 	return nil, "", nil, nil

--- a/producer/oam_test.go
+++ b/producer/oam_test.go
@@ -6,6 +6,7 @@
 package producer
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/omec-project/amf/context"
@@ -25,7 +26,9 @@ type TestCases struct {
 }
 
 func init() {
-	factory.InitConfigFactory("../amfTest/amfcfg.yaml")
+	if err := factory.InitConfigFactory("../amfTest/amfcfg.yaml"); err != nil {
+		fmt.Printf("Error in InitConfigFactory: %v\n", err)
+	}
 
 	self := context.AMF_Self()
 	util.InitAmfContext(self)
@@ -35,7 +38,11 @@ func init() {
 
 func TestHandleOAMPurgeUEContextRequest_UEDeregistered(t *testing.T) {
 	self := context.AMF_Self()
-	self.Drsm, _ = util.MockDrsmInit()
+	var err error
+	self.Drsm, err = util.MockDrsmInit()
+	if err != nil {
+		fmt.Printf("Error in MockDrsmInit: %v\n", err)
+	}
 	amfUe := self.NewAmfUe("imsi-208930100007497")
 
 	HandleOAMPurgeUEContextRequest(amfUe.Supi, "", nil)

--- a/service/amf_server.go
+++ b/service/amf_server.go
@@ -71,7 +71,9 @@ func (s *Server) HandleMessage(srv sdcoreAmfServer.NgapService_HandleMessageServ
 								NfStatus: mi.NfStatusConnected, NfName: req.GnbId,
 							},
 						}
-						metrics.StatWriter.PublishNfStatusEvent(gnbStatus)
+						if err := metrics.StatWriter.PublishNfStatusEvent(gnbStatus); err != nil {
+							log.Printf("Error publishing NfStatusEvent: %v", err)
+						}
 					}
 				}
 				ran.Amf2RanMsgChan = Amf2RanMsgChan
@@ -89,7 +91,9 @@ func (s *Server) HandleMessage(srv sdcoreAmfServer.NgapService_HandleMessageServ
 						NfStatus: mi.NfStatusDisconnected, NfName: req.GnbId,
 					},
 				}
-				metrics.StatWriter.PublishNfStatusEvent(gnbStatus)
+				if err := metrics.StatWriter.PublishNfStatusEvent(gnbStatus); err != nil {
+					log.Printf("Error publishing NfStatusEvent: %v", err)
+				}
 			} else if req.Msgtype == sdcoreAmfServer.MsgType_GNB_CONN {
 				log.Println("New GNB Connected ")
 				// send nf(gnb) status notification
@@ -100,7 +104,9 @@ func (s *Server) HandleMessage(srv sdcoreAmfServer.NgapService_HandleMessageServ
 						NfStatus: mi.NfStatusConnected, NfName: req.GnbId,
 					},
 				}
-				metrics.StatWriter.PublishNfStatusEvent(gnbStatus)
+				if err := metrics.StatWriter.PublishNfStatusEvent(gnbStatus); err != nil {
+					log.Printf("Error publishing NfStatusEvent: %v", err)
+				}
 			} else {
 				ngap.DispatchLb(req, Amf2RanMsgChan)
 			}


### PR DESCRIPTION
Enables the `errcheck` linter and add error checking where missing, simply logging the error.

Also remove the `deadcode` and `varcheck` linters as they are abandoned by their upstream.