### PR TITLE
chore: Enable 'unused' linter and fix reported problems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -242,7 +242,7 @@ linters:
     - govet
     - errcheck
     - staticcheck
-    # - unused
+    - unused
     # - gosimple
     # - structcheck
     - ineffassign

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -60,29 +60,6 @@ func setAltSmfProfile(smCtxt *amf_context.SmContext) error {
 	return fmt.Errorf("no alternate profiles available")
 }
 
-func refreshSmfProfiles(ue *amf_context.AmfUe, smCtxt *amf_context.SmContext, ignoreSmfId string) *[]models.NfProfile {
-	nrfUri := ue.ServingAMF.NrfUri
-	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
-		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
-		Dnn:          optional.NewString(smCtxt.Dnn()),
-		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{smCtxt.Snssai()})),
-	}
-
-	result, err := SendSearchNFInstances(nrfUri, models.NfType_SMF, models.NfType_AMF, &param)
-	if err != nil {
-		return nil
-	}
-
-	var altSmfInst []models.NfProfile
-	// iterate over nf instances to ignore failed NF
-	for _, inst := range result.NfInstances {
-		if inst.NfInstanceId != ignoreSmfId {
-			altSmfInst = append(altSmfInst, inst)
-		}
-	}
-	return &altSmfInst
-}
-
 func SelectSmf(
 	ue *amf_context.AmfUe,
 	anType models.AccessType,

--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -636,24 +636,6 @@ func BuildRegistrationAccept(
 	return nas_security.Encode(ue, m)
 }
 
-func includeConfiguredNssaiCheck(ue *context.AmfUe) bool {
-	if len(ue.ConfiguredNssai) == 0 {
-		return false
-	}
-
-	registrationRequest := ue.RegistrationRequest
-	if registrationRequest.RequestedNSSAI == nil {
-		return true
-	}
-	if ue.NetworkSliceInfo != nil && len(ue.NetworkSliceInfo.RejectedNssaiInPlmn) != 0 {
-		return true
-	}
-	if registrationRequest.NetworkSlicingIndication != nil && registrationRequest.NetworkSlicingIndication.GetDCNI() == 1 {
-		return true
-	}
-	return false
-}
-
 func BuildStatus5GMM(cause uint8) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -78,27 +78,6 @@ func (writer Writer) PublishUeCtxtEvent(ctxt mi.CoreSubscriber, op mi.Subscriber
 	return nil
 }
 
-var nfInstanceId string
-
-// initialised by context package
-func SetNfInstanceId(s string) {
-	nfInstanceId = s
-}
-
-/*
-func PublishMsgEvent(msgType mi.AmfMsgType) error {
-
-	smKafkaMsgEvt := mi.MetricEvent{EventType: mi.CMsgTypeEvt, MsgType: mi.CoreMsgType{MsgType: msgType.String(), SourceNfId: nfInstanceId}}
-	if msg, err := json.Marshal(smKafkaMsgEvt); err != nil {
-		return err
-	} else {
-		logger.KafkaLog.Debugf("publishing msg event[%s] ", msg)
-		StatWriter.SendMessage(msg)
-	}
-	return nil
-}
-*/
-
 func (writer Writer) PublishNfStatusEvent(msgEvent mi.MetricEvent) error {
 	if msg, err := json.Marshal(msgEvent); err != nil {
 		return err

--- a/producer/oam_test.go
+++ b/producer/oam_test.go
@@ -18,13 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type TestCases struct {
-	amfContext         context.AMFContext
-	amfue              context.AmfUe
-	expectedUeFsmState string
-	description        string
-}
-
 func init() {
 	if err := factory.InitConfigFactory("../amfTest/amfcfg.yaml"); err != nil {
 		fmt.Printf("Error in InitConfigFactory: %v\n", err)

--- a/service/init.go
+++ b/service/init.go
@@ -64,8 +64,7 @@ var RocUpdateConfigChannel chan bool
 type (
 	// Config information.
 	Config struct {
-		amfcfg         string
-		heartBeatTimer string
+		amfcfg string
 	}
 )
 

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -14,7 +14,6 @@ import (
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/factory"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/amf/metrics"
 	"github.com/omec-project/nas/security"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/drsm"
@@ -45,7 +44,6 @@ func InitAmfContext(context *context.AMFContext) {
 	if context.NfId == "" {
 		context.NfId = uuid.New().String()
 	}
-	metrics.SetNfInstanceId(context.NfId)
 
 	if configuration.AmfName != "" {
 		context.Name = configuration.AmfName


### PR DESCRIPTION
Enables the `unused` linter and remove unused code reported. Tested with a gnbsim simulation.