### PR TITLE
chore: Enable unconvert linter and fix reported issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -252,7 +252,6 @@ linters:
     #- gomnd
     - goconst
     # - gocognit
-    # - maligned
     # - nestif
     # - gomodguard
     - nakedret
@@ -260,7 +259,7 @@ linters:
     - misspell
     - gofumpt
     - whitespace
-    # - unconvert
+    - unconvert
     - predeclared
     - noctx
     - dogsled

--- a/context/context.go
+++ b/context/context.go
@@ -119,7 +119,7 @@ func (context *AMFContext) TmsiAllocate() int32 {
 		return -1
 	}
 	logger.ContextLog.Infof("Allocate TMSI : %v", val)
-	return int32(val)
+	return val
 }
 
 func (context *AMFContext) AllocateAmfUeNgapID() (int64, error) {

--- a/context/db.go
+++ b/context/db.go
@@ -51,7 +51,7 @@ func AllocateUniqueID(generator **idgenerator.IDGenerator, idName string) (int64
 		//        Later this value can be used to trigger
 		//        creation of new instance
 		minVal := int64((val-1)*8192 + 1)
-		maxVal := int64(minVal + 8192)
+		maxVal := minVal + 8192
 		*generator = idgenerator.NewGenerator(minVal, maxVal)
 	}
 

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1633,7 +1633,7 @@ func HandleUeSliceInfoDelete(ue *context.AmfUe, accessType models.AccessType, ns
 	var problemDetails *models.ProblemDetails
 	ue.SmContextList.Range(func(key, value interface{}) bool {
 		smContext := value.(*context.SmContext)
-		if smContext.Snssai().Sst == int32(nssai.Sst) && smContext.Snssai().Sd == nssai.Sd {
+		if smContext.Snssai().Sst == nssai.Sst && smContext.Snssai().Sd == nssai.Sd {
 			logger.GmmLog.Infof("Deleted Slice [sst: %v, sd: %v]matched with smcontext, sending Release SMContext Request to SMF",
 				smContext.Snssai().Sst, smContext.Snssai().Sd)
 			// send smcontext release request

--- a/nas/handler.go
+++ b/nas/handler.go
@@ -36,7 +36,7 @@ func HandleNAS(ue *context.RanUe, procedureCode int64, nasPdu []byte) {
 		} else {
 			if amfSelf.EnableSctpLb {
 				/* checking the guti-ue belongs to this amf instance */
-				id, err := amfSelf.Drsm.FindOwnerInt32ID(int32(ue.AmfUe.Tmsi))
+				id, err := amfSelf.Drsm.FindOwnerInt32ID(ue.AmfUe.Tmsi)
 				if err != nil {
 					logger.NasLog.Errorf("Error checking guti-ue: %v", err)
 				}

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -1522,7 +1522,7 @@ func HandleInitialUEMessage(ran *context.AmfRan, message *ngapType.NGAPPDU, sctp
 			} else {
 				ranUe.Log.Tracef("find AmfUe [GUTI: %s]", guti)
 				/* checking the guti-ue belongs to this amf instance */
-				id, err := amfSelf.Drsm.FindOwnerInt32ID(int32(amfUe.Tmsi))
+				id, err := amfSelf.Drsm.FindOwnerInt32ID(amfUe.Tmsi)
 				if err != nil {
 					ranUe.Log.Errorf("Error checking the guti-ue in this instance: %v", err)
 				}


### PR DESCRIPTION
Enables the `unconvert` linter and fix reported issues. This simply removes redundant conversion.

Also removes the `maligned` linter that is deprecated.