### PR TITLE
chore: Move http_wrapper dependency to util project

### DIFF
--- a/communication/api_individual_subscription_document.go
+++ b/communication/api_individual_subscription_document.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -56,7 +56,7 @@ func HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, subscriptionData)
+	req := httpwrapper.NewRequest(c.Request, subscriptionData)
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
 	rsp := producer.HandleAMFStatusChangeSubscribeModify(req)
@@ -77,7 +77,7 @@ func HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 
 // AMFStatusChangeUnSubscribe - Namf_Communication AMF Status Change UnSubscribe service Operation
 func HTTPAMFStatusChangeUnSubscribe(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
 	rsp := producer.HandleAMFStatusChangeUnSubscribeRequest(req)

--- a/communication/api_individual_ue_context_document.go
+++ b/communication/api_individual_ue_context_document.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -69,7 +69,7 @@ func HTTPCreateUEContext(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, createUeContextRequest)
+	req := httpwrapper.NewRequest(c.Request, createUeContextRequest)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	rsp := producer.HandleCreateUEContextRequest(req)
 
@@ -132,7 +132,7 @@ func HTTPEBIAssignment(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, assignEbiData)
+	req := httpwrapper.NewRequest(c.Request, assignEbiData)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	rsp := producer.HandleAssignEbiDataRequest(req)
 
@@ -180,7 +180,7 @@ func HTTPRegistrationStatusUpdate(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, ueRegStatusUpdateReqData)
+	req := httpwrapper.NewRequest(c.Request, ueRegStatusUpdateReqData)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	rsp := producer.HandleRegistrationStatusUpdateRequest(req)
 
@@ -228,7 +228,7 @@ func HTTPReleaseUEContext(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, ueContextRelease)
+	req := httpwrapper.NewRequest(c.Request, ueContextRelease)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	rsp := producer.HandleReleaseUEContextRequest(req)
 
@@ -285,7 +285,7 @@ func HTTPUEContextTransfer(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, ueContextTransferRequest)
+	req := httpwrapper.NewRequest(c.Request, ueContextTransferRequest)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	rsp := producer.HandleUEContextTransferRequest(req)
 

--- a/communication/api_n1_n2_individual_subscription_document.go
+++ b/communication/api_n1_n2_individual_subscription_document.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
 
 // N1N2MessageUnSubscribe - Namf_Communication N1N2 Message UnSubscribe (UE Specific) service Operation
 func HTTPN1N2MessageUnSubscribe(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 

--- a/communication/api_n1_n2_message_collection_document.go
+++ b/communication/api_n1_n2_message_collection_document.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -69,7 +69,7 @@ func HTTPN1N2MessageTransfer(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, n1n2MessageTransferRequest)
+	req := httpwrapper.NewRequest(c.Request, n1n2MessageTransferRequest)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	req.Params["reqUri"] = c.Request.RequestURI
 
@@ -93,7 +93,7 @@ func HTTPN1N2MessageTransfer(c *gin.Context) {
 }
 
 func HTTPN1N2MessageTransferStatus(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	req.Params["reqUri"] = c.Request.RequestURI
 

--- a/communication/api_n1_n2_subscriptions_collection_for_individual_ue_contexts_document.go
+++ b/communication/api_n1_n2_subscriptions_collection_for_individual_ue_contexts_document.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -55,7 +55,7 @@ func HTTPN1N2MessageSubscribe(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, ueN1N2InfoSubscriptionCreateData)
+	req := httpwrapper.NewRequest(c.Request, ueN1N2InfoSubscriptionCreateData)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 
 	rsp := producer.HandleN1N2MessageSubscirbeRequest(req)

--- a/communication/api_subscriptions_collection_document.go
+++ b/communication/api_subscriptions_collection_document.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -56,7 +56,7 @@ func HTTPAMFStatusChangeSubscribe(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, subscriptionData)
+	req := httpwrapper.NewRequest(c.Request, subscriptionData)
 	rsp := producer.HandleAMFStatusChangeSubscribeRequest(req)
 
 	for key, val := range rsp.Header {

--- a/eventexposure/api_individual_subscription_document.go
+++ b/eventexposure/api_individual_subscription_document.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
 
 // DeleteSubscription - Namf_EventExposure Unsubscribe service Operation
 func HTTPDeleteSubscription(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["subscriptionId"] = c.Param("subscriptionId")
 
 	rsp := producer.HandleDeleteAMFEventSubscription(req)
@@ -81,7 +81,7 @@ func HTTPModifySubscription(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, modifySubscriptionRequest)
+	req := httpwrapper.NewRequest(c.Request, modifySubscriptionRequest)
 	req.Params["subscriptionId"] = c.Param("subscriptionId")
 
 	rsp := producer.HandleModifyAMFEventSubscription(req)

--- a/eventexposure/api_subscriptions_collection_document.go
+++ b/eventexposure/api_subscriptions_collection_document.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -56,7 +56,7 @@ func HTTPCreateSubscription(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, createEventSubscription)
+	req := httpwrapper.NewRequest(c.Request, createEventSubscription)
 
 	rsp := producer.HandleCreateAMFEventSubscription(req)
 

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,10 @@ require (
 	github.com/omec-project/aper v1.1.0
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
-	github.com/omec-project/http_wrapper v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/nas v1.1.4
 	github.com/omec-project/ngap v1.1.0
+	github.com/omec-project/nrf v1.0.2-0.20240209194459-21f8e64ba367
 	github.com/omec-project/openapi v1.1.0
 	github.com/omec-project/path_util v1.1.0
 	github.com/omec-project/util v1.0.12
@@ -72,7 +72,7 @@ require (
 	github.com/go-playground/validator/v10 v10.15.5 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt v3.2.1+incompatible // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
@@ -89,7 +89,6 @@ require (
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/omec-project/logger_conf v1.1.0 // indirect
 	github.com/omec-project/metricfunc v1.1.1
-	github.com/omec-project/nrf v1.0.1
 	github.com/omec-project/util_3gpp v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,7 +65,6 @@ github.com/bytedance/sonic v1.10.1/go.mod h1:iZcSUejdk5aukTND/Eu/ivjQuEL0Cu9/rf5
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
@@ -80,11 +79,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/cgroups v1.0.4/go.mod h1:nLNQtsF7Sl2HxNebu77i1R0oDlhiTG+kO4JTrUzo6IA=
 github.com/containerd/containerd v1.6.6 h1:xJNPhbrmz8xAMDNoVjHy9YHtWwEQNS+CDkcIRh7t8Y0=
@@ -93,7 +88,6 @@ github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmf
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -116,7 +110,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
@@ -184,8 +177,9 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -231,7 +225,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -337,18 +330,14 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/omec-project/MongoDBLibrary v1.1.2/go.mod h1:bchS8sexPvTzgcA+fGzGeMyQk2Ji2xyAYgXDg6wOg1I=
 github.com/omec-project/MongoDBLibrary v1.1.3 h1:3/2Luxl4YBe9cP2cRNtPruroBGonmiQbnCviYby1fo4=
 github.com/omec-project/MongoDBLibrary v1.1.3/go.mod h1:bchS8sexPvTzgcA+fGzGeMyQk2Ji2xyAYgXDg6wOg1I=
-github.com/omec-project/TimeDecode v1.1.0/go.mod h1:yqMSNEIvj60RA9vGmwqsemuSA4+J23NVg91Xy+1Dfcs=
 github.com/omec-project/aper v1.1.0 h1:4FkTkDNGBWnTtEgCDuEitFjww1CJWVQhGqMs91triuU=
 github.com/omec-project/aper v1.1.0/go.mod h1:oOkKRI2BIo8SHpCsEzNbo9qiowEtEy3q+wmO7TuDrx4=
 github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVnzCyMd4=
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
-github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
-github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
 github.com/omec-project/logger_conf v1.0.100-dev/go.mod h1:Upj0MgzSpB/Ifw+3WsBaYbqWuF4SyyUeKqW7/HhL8Aw=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=
@@ -361,8 +350,8 @@ github.com/omec-project/nas v1.1.4 h1:kQvTTkjJ8eSb6/noeU8Bp6AOo4KeSvUII9CneFADnY
 github.com/omec-project/nas v1.1.4/go.mod h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
 github.com/omec-project/ngap v1.1.0 h1:J9bkPEzzyGd1787nGY/aZVp3gckkZBoJB4tkTo59eyw=
 github.com/omec-project/ngap v1.1.0/go.mod h1:A+T3+JKk+6AuhnMr6W319Tc7E176ig6rIRDVSKQ7E5g=
-github.com/omec-project/nrf v1.0.1 h1:+qtpnyntWhpuQqxwofOSukvPkUo+kXm/0PEMo4YrLZk=
-github.com/omec-project/nrf v1.0.1/go.mod h1:bnakoadGIlS8e0b9ifBqQuqPLGbTVMbHGteccF8XM30=
+github.com/omec-project/nrf v1.0.2-0.20240209194459-21f8e64ba367 h1:ofrBygV6bAHGpE0MEy+rzbZrQh/8BMIcPx48BgcgRhU=
+github.com/omec-project/nrf v1.0.2-0.20240209194459-21f8e64ba367/go.mod h1:vo0xD2PYp+DItZ0kX906GYMErxV6VMX8JauHW7/l23M=
 github.com/omec-project/openapi v1.0.100-dev/go.mod h1:Fv9ajWROYypcNER+ZwWXPhLCdV4pBz75KqFp/R/2gCw=
 github.com/omec-project/openapi v1.1.0 h1:N3v59+FM2V/eCv2Au10kbyeTf1DsScJkEdkDEcCdKE8=
 github.com/omec-project/openapi v1.1.0/go.mod h1:Fv9ajWROYypcNER+ZwWXPhLCdV4pBz75KqFp/R/2gCw=
@@ -412,7 +401,6 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
@@ -421,7 +409,6 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -477,7 +464,6 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ugorji/go/codec v1.2.1/go.mod h1:s/WxCRi46t8rA+fowL40EnmD7ec0XhR7ZypxeBNdzsM=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.14 h1:ebbhrRiGK2i4naQJr+1Xj92HXZCrK7MsyTS/ob3HnAk=
 github.com/urfave/cli v1.22.14/go.mod h1:X0eDS6pD6Exaclxm99NJ3FiCDRED7vIHpx2mDOHLvkA=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -846,7 +832,6 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
-google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.61.0 h1:TOvOcuXn30kRao+gfcvsebNEa5iZIiLkisYEkf7R7o0=
 google.golang.org/grpc v1.61.0/go.mod h1:VUbo7IFqmF1QtCAstipjG0GIoq49KvMe9+h1jFLBNJs=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/httpcallback/api_am_policy_control_update_notify.go
+++ b/httpcallback/api_am_policy_control_update_notify.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -46,7 +46,7 @@ func HTTPAmPolicyControlUpdateNotifyUpdate(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, policyUpdate)
+	req := httpwrapper.NewRequest(c.Request, policyUpdate)
 	req.Params["polAssoId"] = c.Params.ByName("polAssoId")
 
 	rsp := producer.HandleAmPolicyControlUpdateNotifyUpdate(req)
@@ -94,7 +94,7 @@ func HTTPAmPolicyControlUpdateNotifyTerminate(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, terminationNotification)
+	req := httpwrapper.NewRequest(c.Request, terminationNotification)
 	req.Params["polAssoId"] = c.Params.ByName("polAssoId")
 
 	rsp := producer.HandleAmPolicyControlUpdateNotifyTerminate(req)

--- a/httpcallback/api_n1_message_notify.go
+++ b/httpcallback/api_n1_message_notify.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -46,7 +46,7 @@ func HTTPN1MessageNotify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, n1MessageNotification)
+	req := httpwrapper.NewRequest(c.Request, n1MessageNotification)
 
 	rsp := producer.HandleN1MessageNotify(req)
 

--- a/httpcallback/api_nf_subscribe_notify.go
+++ b/httpcallback/api_nf_subscribe_notify.go
@@ -14,7 +14,7 @@ import (
 	"github.com/omec-project/openapi/models"
 
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 )
 
@@ -47,7 +47,7 @@ func HTTPNfSubscriptionStatusNotify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, nfSubscriptionStatusNotification)
+	req := httpwrapper.NewRequest(c.Request, nfSubscriptionStatusNotification)
 
 	rsp := producer.HandleNfSubscriptionStatusNotify(req)
 

--- a/httpcallback/api_sm_context_status_notify.go
+++ b/httpcallback/api_sm_context_status_notify.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -46,7 +46,7 @@ func HTTPSmContextStatusNotify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, smContextStatusNotification)
+	req := httpwrapper.NewRequest(c.Request, smContextStatusNotification)
 	req.Params["guti"] = c.Params.ByName("guti")
 	req.Params["pduSessionId"] = c.Params.ByName("pduSessionId")
 

--- a/location/api_individual_ue_context_document.go
+++ b/location/api_individual_ue_context_document.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -56,7 +56,7 @@ func HTTPProvideLocationInfo(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, requestLocInfo)
+	req := httpwrapper.NewRequest(c.Request, requestLocInfo)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 
 	rsp := producer.HandleProvideLocationInfoRequest(req)

--- a/mt/api_ue_context_document.go
+++ b/mt/api_ue_context_document.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
 
 // ProvideDomainSelectionInfo - Namf_MT Provide Domain Selection Info service Operation
 func HTTPProvideDomainSelectionInfo(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueContextId"] = c.Params.ByName("ueContextId")
 	infoClassQuery := c.Query("info-class")
 	req.Query.Add("info-class", infoClassQuery)

--- a/oam/api_purge_ue_context.go
+++ b/oam/api_purge_ue_context.go
@@ -13,7 +13,7 @@ import (
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 
 	"github.com/omec-project/openapi/models"
 )
@@ -22,7 +22,7 @@ func HTTPPurgeUEContext(c *gin.Context) {
 	setCorsHeader(c)
 
 	amfSelf := context.AMF_Self()
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	if supi, exists := c.Params.Get("supi"); exists {
 		req.Params["supi"] = supi
 		reqUri := req.URL.RequestURI()
@@ -53,7 +53,7 @@ func HTTPAmfInstanceDown(c *gin.Context) {
 
 	nfId, _ := c.Params.Get("nfid")
 	logger.ProducerLog.Infof("AMF Instance Down Notification from NRF: %v", nfId)
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	if nfInstanceId, exists := c.Params.Get("nfid"); exists {
 		req.Params["nfid"] = nfInstanceId
 		self := context.AMF_Self()

--- a/oam/api_registered_ue_context.go
+++ b/oam/api_registered_ue_context.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -27,7 +27,7 @@ func setCorsHeader(c *gin.Context) {
 func HTTPRegisteredUEContext(c *gin.Context) {
 	setCorsHeader(c)
 
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	if supi, exists := c.Params.Get("supi"); exists {
 		req.Params["supi"] = supi
 	}
@@ -51,7 +51,7 @@ func HTTPRegisteredUEContext(c *gin.Context) {
 func HTTPGetActiveUes(c *gin.Context) {
 	setCorsHeader(c)
 
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 
 	rsp := producer.HandleOAMActiveUEContextsFromDB(req)
 

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -21,12 +21,12 @@ import (
 	"github.com/omec-project/amf/nas"
 	ngap_message "github.com/omec-project/amf/ngap/message"
 	"github.com/omec-project/amf/util"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nas/nasConvert"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/ngap/ngapType"
 	nrf_cache "github.com/omec-project/nrf/nrfcache"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func SmContextHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}, interface{}) {
@@ -51,7 +51,7 @@ func SmContextHandler(s1, s2 string, msg interface{}) (interface{}, string, inte
 	return nil, "", nil, nil
 }
 
-func HandleSmContextStatusNotify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleSmContextStatusNotify(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	var ok bool
 	logger.ProducerLog.Infoln("[AMF] Handle SmContext Status Notify")
@@ -67,7 +67,7 @@ func HandleSmContextStatusNotify(request *http_wrapper.Request) *http_wrapper.Re
 			Cause:  "CONTEXT_NOT_FOUND",
 			Detail: fmt.Sprintf("Guti[%s] Not Found", guti),
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
 	smContextStatusNotification := request.Body.(models.SmContextStatusNotification)
@@ -82,9 +82,9 @@ func HandleSmContextStatusNotify(request *http_wrapper.Request) *http_wrapper.Re
 	msg := <-sbiMsg.Result
 	// problemDetails := SmContextStatusNotifyProcedure(guti, int32(pduSessionID), smContextStatusNotification)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -202,7 +202,7 @@ func SmContextStatusNotifyProcedure(guti string, pduSessionID int32,
 	return nil
 }
 
-func HandleAmPolicyControlUpdateNotifyUpdate(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAmPolicyControlUpdateNotifyUpdate(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	var ok bool
 	logger.ProducerLog.Infoln("Handle AM Policy Control Update Notify [Policy update notification]")
@@ -218,7 +218,7 @@ func HandleAmPolicyControlUpdateNotifyUpdate(request *http_wrapper.Request) *htt
 			Cause:  "CONTEXT_NOT_FOUND",
 			Detail: fmt.Sprintf("Policy Association ID[%s] Not Found", polAssoID),
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: polAssoID,
@@ -232,9 +232,9 @@ func HandleAmPolicyControlUpdateNotifyUpdate(request *http_wrapper.Request) *htt
 	// problemDetails := AmPolicyControlUpdateNotifyUpdateProcedure(polAssoID, policyUpdate)
 
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -305,7 +305,7 @@ func AmPolicyControlUpdateNotifyUpdateProcedure(polAssoID string,
 }
 
 // TS 29.507 4.2.4.3
-func HandleAmPolicyControlUpdateNotifyTerminate(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAmPolicyControlUpdateNotifyTerminate(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	logger.ProducerLog.Infoln("Handle AM Policy Control Update Notify [Request for termination of the policy association]")
 
@@ -320,7 +320,7 @@ func HandleAmPolicyControlUpdateNotifyTerminate(request *http_wrapper.Request) *
 			Cause:  "CONTEXT_NOT_FOUND",
 			Detail: fmt.Sprintf("Policy Association ID[%s] Not Found", polAssoID),
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: polAssoID,
@@ -334,9 +334,9 @@ func HandleAmPolicyControlUpdateNotifyTerminate(request *http_wrapper.Request) *
 
 	// problemDetails := AmPolicyControlUpdateNotifyTerminateProcedure(polAssoID, terminationNotification)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -370,16 +370,16 @@ func AmPolicyControlUpdateNotifyTerminateProcedure(polAssoID string,
 }
 
 // TS 23.502 4.2.2.2.3 Registration with AMF re-allocation
-func HandleN1MessageNotify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleN1MessageNotify(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.ProducerLog.Infoln("[AMF] Handle N1 Message Notify")
 
 	n1MessageNotify := request.Body.(models.N1MessageNotify)
 
 	problemDetails := N1MessageNotifyProcedure(n1MessageNotify)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -441,16 +441,16 @@ func N1MessageNotifyProcedure(n1MessageNotify models.N1MessageNotify) *models.Pr
 	return nil
 }
 
-func HandleNfSubscriptionStatusNotify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNfSubscriptionStatusNotify(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.ProducerLog.Traceln("[AMF] Handle NF Status Notify")
 
 	notificationData := request.Body.(models.NotificationData)
 
 	problemDetails := NfSubscriptionStatusNotifyProcedure(notificationData)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -12,24 +12,24 @@ import (
 
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleCreateAMFEventSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleCreateAMFEventSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	createEventSubscription := request.Body.(models.AmfCreateEventSubscription)
 
 	createdEventSubscription, problemDetails := CreateAMFEventSubscriptionProcedure(createEventSubscription)
 	if createdEventSubscription != nil {
-		return http_wrapper.NewResponse(http.StatusCreated, nil, createdEventSubscription)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, createdEventSubscription)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusInternalServerError,
 			Cause:  "UNSPECIFIED_NF_FAILURE",
 		}
-		return http_wrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 	}
 }
 
@@ -192,16 +192,16 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 	return createdEventSubscription, nil
 }
 
-func HandleDeleteAMFEventSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeleteAMFEventSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.EeLog.Infoln("Handle Delete AMF Event Subscription")
 
 	subscriptionID := request.Params["subscriptionId"]
 
 	problemDetails := DeleteAMFEventSubscriptionProcedure(subscriptionID)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, nil)
+		return httpwrapper.NewResponse(http.StatusOK, nil, nil)
 	}
 }
 
@@ -226,7 +226,7 @@ func DeleteAMFEventSubscriptionProcedure(subscriptionID string) *models.ProblemD
 	return nil
 }
 
-func HandleModifyAMFEventSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleModifyAMFEventSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.EeLog.Infoln("Handle Modify AMF Event Subscription")
 
 	subscriptionID := request.Params["subscriptionId"]
@@ -235,15 +235,15 @@ func HandleModifyAMFEventSubscription(request *http_wrapper.Request) *http_wrapp
 	updatedEventSubscription, problemDetails := ModifyAMFEventSubscriptionProcedure(subscriptionID,
 		modifySubscriptionRequest)
 	if updatedEventSubscription != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, updatedEventSubscription)
+		return httpwrapper.NewResponse(http.StatusOK, nil, updatedEventSubscription)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusInternalServerError,
 			Cause:  "UNSPECIFIED_NF_FAILURE",
 		}
-		return http_wrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 	}
 }
 

--- a/producer/location_info.go
+++ b/producer/location_info.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func LocationInfoHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}, interface{}) {
@@ -25,7 +25,7 @@ func LocationInfoHandler(s1, s2 string, msg interface{}) (interface{}, string, i
 	return nil, "", nil, nil
 }
 
-func HandleProvideLocationInfoRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleProvideLocationInfoRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	var ok bool
 	logger.ProducerLog.Info("Handle Provide Location Info Request")
@@ -39,7 +39,7 @@ func HandleProvideLocationInfoRequest(request *http_wrapper.Request) *http_wrapp
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 
 	sbiMsg := context.SbiMsg{
@@ -57,9 +57,9 @@ func HandleProvideLocationInfoRequest(request *http_wrapper.Request) *http_wrapp
 	}
 	// provideLocInfo, problemDetails := ProvideLocationInfoProcedure(requestLocInfo, ueContextID)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, provideLocInfo)
+		return httpwrapper.NewResponse(http.StatusOK, nil, provideLocInfo)
 	}
 }
 

--- a/producer/mt.go
+++ b/producer/mt.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func MtHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}, interface{}) {
@@ -25,7 +25,7 @@ func MtHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}
 	return nil, "", nil, nil
 }
 
-func HandleProvideDomainSelectionInfoRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleProvideDomainSelectionInfoRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	var ok bool
 	logger.MtLog.Info("Handle Provide Domain Selection Info Request")
@@ -41,7 +41,7 @@ func HandleProvideDomainSelectionInfoRequest(request *http_wrapper.Request) *htt
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -59,9 +59,9 @@ func HandleProvideDomainSelectionInfoRequest(request *http_wrapper.Request) *htt
 	// ueContextInfo, problemDetails := ProvideDomainSelectionInfoProcedure(ueContextID,
 	//	infoClassQuery, supportedFeaturesQuery)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(models.ProblemDetails).Status), nil, msg.ProblemDetails.(models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(models.ProblemDetails).Status), nil, msg.ProblemDetails.(models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, ueContextInfo)
+		return httpwrapper.NewResponse(http.StatusOK, nil, ueContextInfo)
 	}
 }
 

--- a/producer/n1n2message.go
+++ b/producer/n1n2message.go
@@ -17,10 +17,10 @@ import (
 	ngap_message "github.com/omec-project/amf/ngap/message"
 	"github.com/omec-project/amf/producer/callback"
 	"github.com/omec-project/aper"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/ngap/ngapType"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func ProducerHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}, interface{}) {
@@ -40,7 +40,7 @@ func ProducerHandler(s1, s2 string, msg interface{}) (interface{}, string, inter
 }
 
 // TS23502 4.2.3.3, 4.2.4.3, 4.3.2.2, 4.3.2.3, 4.3.3.2, 4.3.7
-func HandleN1N2MessageTransferRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleN1N2MessageTransferRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	var ue *context.AmfUe
 	var ok bool
 	var problemDetails *models.ProblemDetails
@@ -57,7 +57,7 @@ func HandleN1N2MessageTransferRequest(request *http_wrapper.Request) *http_wrapp
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -84,20 +84,20 @@ func HandleN1N2MessageTransferRequest(request *http_wrapper.Request) *http_wrapp
 	//			ueContextID, reqUri, n1n2MessageTransferRequest)
 
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else if transferErr != nil {
-		return http_wrapper.NewResponse(int(transferErr.Error.Status), nil, transferErr)
+		return httpwrapper.NewResponse(int(transferErr.Error.Status), nil, transferErr)
 	} else if n1n2MessageTransferRspData != nil {
 		switch n1n2MessageTransferRspData.Cause {
 		case models.N1N2MessageTransferCause_N1_MSG_NOT_TRANSFERRED:
 			fallthrough
 		case models.N1N2MessageTransferCause_N1_N2_TRANSFER_INITIATED:
-			return http_wrapper.NewResponse(http.StatusOK, nil, n1n2MessageTransferRspData)
+			return httpwrapper.NewResponse(http.StatusOK, nil, n1n2MessageTransferRspData)
 		case models.N1N2MessageTransferCause_ATTEMPTING_TO_REACH_UE:
 			headers := http.Header{
 				"Location": {locationHeader},
 			}
-			return http_wrapper.NewResponse(http.StatusAccepted, headers, n1n2MessageTransferRspData)
+			return httpwrapper.NewResponse(http.StatusAccepted, headers, n1n2MessageTransferRspData)
 		}
 	}
 
@@ -105,7 +105,7 @@ func HandleN1N2MessageTransferRequest(request *http_wrapper.Request) *http_wrapp
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 // There are 4 possible return value for this function:
@@ -423,7 +423,7 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 	}
 }
 
-func HandleN1N2MessageTransferStatusRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleN1N2MessageTransferStatusRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle N1N2Message Transfer Status Request")
 
 	ueContextID := request.Params["ueContextId"]
@@ -437,7 +437,7 @@ func HandleN1N2MessageTransferStatusRequest(request *http_wrapper.Request) *http
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -456,9 +456,9 @@ func HandleN1N2MessageTransferStatusRequest(request *http_wrapper.Request) *http
 
 	// status, problemDetails := N1N2MessageTransferStatusProcedure(ueContextID, reqUri)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, n1n2MessageRspData)
+		return httpwrapper.NewResponse(http.StatusOK, nil, n1n2MessageRspData)
 	}
 }
 
@@ -490,7 +490,7 @@ func N1N2MessageTransferStatusProcedure(ueContextID string, reqUri string) (mode
 }
 
 // TS 29.518 5.2.2.3.3
-func HandleN1N2MessageSubscirbeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleN1N2MessageSubscirbeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	ueN1N2InfoSubscriptionCreateData := request.Body.(models.UeN1N2InfoSubscriptionCreateData)
 	ueContextID := request.Params["ueContextId"]
 
@@ -502,7 +502,7 @@ func HandleN1N2MessageSubscirbeRequest(request *http_wrapper.Request) *http_wrap
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -520,9 +520,9 @@ func HandleN1N2MessageSubscirbeRequest(request *http_wrapper.Request) *http_wrap
 	}
 	// ueN1N2InfoSubscriptionCreatedData, problemDetails := N1N2MessageSubscribeProcedure(ueContextID, ueN1N2InfoSubscriptionCreateData)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusCreated, nil, n1n2MessageRspData)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, n1n2MessageRspData)
 	}
 }
 
@@ -557,7 +557,7 @@ func N1N2MessageSubscribeProcedure(ueContextID string,
 	return ueN1N2InfoSubscriptionCreatedData, nil
 }
 
-func HandleN1N2MessageUnSubscribeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleN1N2MessageUnSubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle N1N2Message Unsubscribe Request")
 
 	ueContextID := request.Params["ueContextId"]
@@ -565,9 +565,9 @@ func HandleN1N2MessageUnSubscribeRequest(request *http_wrapper.Request) *http_wr
 
 	problemDetails := N1N2MessageUnSubscribeProcedure(ueContextID, subscriptionID)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -13,9 +13,9 @@ import (
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/gmm"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/fsm"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 type PduSession struct {
@@ -88,20 +88,20 @@ func HandleOAMPurgeUEContextRequest(supi, reqUri string, msg interface{}) (inter
 	return nil, "", nil, nil
 }
 
-func HandleOAMRegisteredUEContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleOAMRegisteredUEContext(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.ProducerLog.Infof("[OAM] Handle Registered UE Context")
 
 	supi := request.Params["supi"]
 
 	ueContexts, problemDetails := OAMRegisteredUEContextProcedure(supi)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, ueContexts)
+		return httpwrapper.NewResponse(http.StatusOK, nil, ueContexts)
 	}
 }
 
-func HandleOAMActiveUEContextsFromDB(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleOAMActiveUEContextsFromDB(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.ProducerLog.Infof("[OAM] Handle Active UE Contexts Request")
 	var ueContexts []ActiveUeContext
 	ueList := context.DbFetchAllEntries()
@@ -150,10 +150,10 @@ func HandleOAMActiveUEContextsFromDB(request *http_wrapper.Request) *http_wrappe
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	return http_wrapper.NewResponse(http.StatusOK, nil, ueContexts)
+	return httpwrapper.NewResponse(http.StatusOK, nil, ueContexts)
 }
 
 func OAMRegisteredUEContextProcedure(supi string) (UEContexts, *models.ProblemDetails) {

--- a/producer/subscription.go
+++ b/producer/subscription.go
@@ -11,25 +11,25 @@ import (
 
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // TS 29.518 5.2.2.5.1
-func HandleAMFStatusChangeSubscribeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAMFStatusChangeSubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle AMF Status Change Subscribe Request")
 
 	subscriptionDataReq := request.Body.(models.SubscriptionData)
 
 	subscriptionDataRsp, locationHeader, problemDetails := AMFStatusChangeSubscribeProcedure(subscriptionDataReq)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
 	headers := http.Header{
 		"Location": {locationHeader},
 	}
-	return http_wrapper.NewResponse(http.StatusCreated, headers, subscriptionDataRsp)
+	return httpwrapper.NewResponse(http.StatusCreated, headers, subscriptionDataRsp)
 }
 
 func AMFStatusChangeSubscribeProcedure(subscriptionDataReq models.SubscriptionData) (
@@ -61,16 +61,16 @@ func AMFStatusChangeSubscribeProcedure(subscriptionDataReq models.SubscriptionDa
 }
 
 // TS 29.518 5.2.2.5.2
-func HandleAMFStatusChangeUnSubscribeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAMFStatusChangeUnSubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle AMF Status Change UnSubscribe Request")
 
 	subscriptionID := request.Params["subscriptionId"]
 
 	problemDetails := AMFStatusChangeUnSubscribeProcedure(subscriptionID)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -90,7 +90,7 @@ func AMFStatusChangeUnSubscribeProcedure(subscriptionID string) (problemDetails 
 }
 
 // TS 29.518 5.2.2.5.1.3
-func HandleAMFStatusChangeSubscribeModify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAMFStatusChangeSubscribeModify(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle AMF Status Change Subscribe Modify Request")
 
 	updateSubscriptionData := request.Body.(models.SubscriptionData)
@@ -99,9 +99,9 @@ func HandleAMFStatusChangeSubscribeModify(request *http_wrapper.Request) *http_w
 	updatedSubscriptionData, problemDetails := AMFStatusChangeSubscribeModifyProcedure(subscriptionID,
 		updateSubscriptionData)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusAccepted, nil, updatedSubscriptionData)
+		return httpwrapper.NewResponse(http.StatusAccepted, nil, updatedSubscriptionData)
 	}
 }
 

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -13,8 +13,8 @@ import (
 	"github.com/omec-project/amf/consumer"
 	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func UeContextHandler(s1, s2 string, msg interface{}) (interface{}, string, interface{}, interface{}) {
@@ -40,7 +40,7 @@ func UeContextHandler(s1, s2 string, msg interface{}) (interface{}, string, inte
 }
 
 // TS 29.518 5.2.2.2.3
-func HandleCreateUEContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleCreateUEContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Infof("Handle Create UE Context Request")
 
 	createUeContextRequest := request.Body.(models.CreateUeContextRequest)
@@ -54,7 +54,7 @@ func HandleCreateUEContextRequest(request *http_wrapper.Request) *http_wrapper.R
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -75,9 +75,9 @@ func HandleCreateUEContextRequest(request *http_wrapper.Request) *http_wrapper.R
 	}
 	// createUeContextResponse, ueContextCreateError := CreateUEContextProcedure(ueContextID, createUeContextRequest)
 	if ueContextCreateErr != nil {
-		return http_wrapper.NewResponse(int(ueContextCreateErr.Error.Status), nil, ueContextCreateErr)
+		return httpwrapper.NewResponse(int(ueContextCreateErr.Error.Status), nil, ueContextCreateErr)
 	} else {
-		return http_wrapper.NewResponse(http.StatusCreated, nil, createUeContextRspData)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, createUeContextRspData)
 	}
 }
 
@@ -176,12 +176,12 @@ func CreateUEContextProcedure(ueContextID string, createUeContextRequest models.
 	//response.PcfReselectedInd = false // TODO:When  Target AMF selects a nw PCF for AM policy, set the flag to true.
 	//
 
-	// return http_wrapper.NewResponse(http.StatusCreated, nil, createUeContextResponse)
+	// return httpwrapper.NewResponse(http.StatusCreated, nil, createUeContextResponse)
 	return createUeContextResponse, nil
 }
 
 // TS 29.518 5.2.2.2.4
-func HandleReleaseUEContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleReleaseUEContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle Release UE Context Request")
 
 	ueContextRelease := request.Body.(models.UeContextRelease)
@@ -194,7 +194,7 @@ func HandleReleaseUEContextRequest(request *http_wrapper.Request) *http_wrapper.
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -208,9 +208,9 @@ func HandleReleaseUEContextRequest(request *http_wrapper.Request) *http_wrapper.
 
 	// problemDetails := ReleaseUEContextProcedure(ueContextID, ueContextRelease)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -251,7 +251,7 @@ func ReleaseUEContextProcedure(ueContextID string, ueContextRelease models.UeCon
 }
 
 // TS 29.518 5.2.2.2.1
-func HandleUEContextTransferRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUEContextTransferRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle UE Context Transfer Request")
 
 	ueContextTransferRequest := request.Body.(models.UeContextTransferRequest)
@@ -265,7 +265,7 @@ func HandleUEContextTransferRequest(request *http_wrapper.Request) *http_wrapper
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -283,9 +283,9 @@ func HandleUEContextTransferRequest(request *http_wrapper.Request) *http_wrapper
 
 	// ueContextTransferResponse, problemDetails := UEContextTransferProcedure(ueContextID, ueContextTransferRequest)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, ueContextTransferResponse)
+		return httpwrapper.NewResponse(http.StatusOK, nil, ueContextTransferResponse)
 	}
 }
 
@@ -495,7 +495,7 @@ func buildAmPolicyReqTriggers(triggers []models.RequestTrigger) (amPolicyReqTrig
 }
 
 // TS 29.518 5.2.2.6
-func HandleAssignEbiDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAssignEbiDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle Assign Ebi Data Request")
 
 	assignEbiData := request.Body.(models.AssignEbiData)
@@ -510,7 +510,7 @@ func HandleAssignEbiDataRequest(request *http_wrapper.Request) *http_wrapper.Res
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -531,11 +531,11 @@ func HandleAssignEbiDataRequest(request *http_wrapper.Request) *http_wrapper.Res
 	}
 
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else if assignEbiErr != nil {
-		return http_wrapper.NewResponse(int(assignEbiErr.Error.Status), nil, assignEbiErr)
+		return httpwrapper.NewResponse(int(assignEbiErr.Error.Status), nil, assignEbiErr)
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, assignEbiRspData)
+		return httpwrapper.NewResponse(http.StatusOK, nil, assignEbiRspData)
 	}
 }
 
@@ -565,7 +565,7 @@ func AssignEbiDataProcedure(ueContextID string, assignEbiData models.AssignEbiDa
 }
 
 // TS 29.518 5.2.2.2.2
-func HandleRegistrationStatusUpdateRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle Registration Status Update Request")
 
 	ueRegStatusUpdateReqData := request.Body.(models.UeRegStatusUpdateReqData)
@@ -579,7 +579,7 @@ func HandleRegistrationStatusUpdateRequest(request *http_wrapper.Request) *http_
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -596,9 +596,9 @@ func HandleRegistrationStatusUpdateRequest(request *http_wrapper.Request) *http_
 	}
 	// ueRegStatusUpdateRspData, problemDetails := RegistrationStatusUpdateProcedure(ueContextID, ueRegStatusUpdateReqData)
 	if msg.ProblemDetails != nil {
-		return http_wrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
+		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
 	} else {
-		return http_wrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
+		return httpwrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
 	}
 }
 


### PR DESCRIPTION
Moves the `http_wrapper` dependency to the `util` project. Tested with a successful `gnbsim` simulation.