### PR TITLE
Add docker push and stale Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Intel Corporation
+name: Docker image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+env:
+  REGISTRY: registry.aetherproject.org
+  DOCKER_REGISTRY: registry.aetherproject.org/
+  DOCKER_REPOSITORY: sdcore/
+
+jobs:
+  push-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - run: echo GIT_SHA_SHORT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
+
+      - id: docker-login
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.AETHER_REGISTRY_USERNAME }}
+          password: ${{ secrets.AETHER_REGISTRY_PASSWORD }}
+
+      - name: Build and push "master-latest" Docker image
+        env:
+          DOCKER_TAG: master-latest
+        run: |
+          make docker-build
+          make docker-push
+
+      - name: Build and push "master-GIT_SHA" Docker image
+        env:
+          DOCKER_TAG: master-${{ env.GIT_SHA_SHORT }}
+        run: |
+          make docker-build
+          make docker-push

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Intel Corporation
+name: Stale issue/pr
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been stale for 30 days and will be closed in 5 days. Comment to keep it open.'
+        stale-pr-message: 'This pull request has been stale for 30 days and will be closed in 5 days. Comment to keep it open.'
+        stale-issue-label: 'stale/issue'
+        stale-pr-label: 'stale/pr'
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
Add two GitHub Actions:
- Docker push to push Docker images to Aether registry
- Stale to mark issues/PRs as stale after a month of inactivity