### PR TITLE
chore: Adding unit tests for custom Webui URL

### DIFF
--- a/amfTest/amfcfg.yaml
+++ b/amfTest/amfcfg.yaml
@@ -45,7 +45,6 @@ configuration:
   supportDnnList:  # the DNN (Data Network Name) list supported by this AMF
     - internet
   nrfUri: http://127.0.0.10:8000 # a valid URI of NRF
-  webuiUri: webui:9876 # a valid URI of Webui
   security:  # NAS security parameters
     integrityOrder: # the priority of integrity algorithms
       - NIA2

--- a/amfTest/amfcfg_with_custom_webui_url.yaml
+++ b/amfTest/amfcfg_with_custom_webui_url.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Canonical Ltd.
+
+info:
+  version: 1.0.0
+  description: AMF initial local configuration
+
+configuration:
+  amfName: AMF # the name of this AMF
+  webuiUri: myspecialwebui:9872 # a valid URI of Webui
+
+

--- a/amfTest/amfcfg_with_custom_webui_url.yaml
+++ b/amfTest/amfcfg_with_custom_webui_url.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Canonical Ltd.
+# SPDX-FileCopyrightText: 2024 Canonical Ltd.
 
 info:
   version: 1.0.0

--- a/factory/amf_config_test.go
+++ b/factory/amf_config_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Canonical Ltd.
+// SPDX-FileCopyrightText: 2024 Canonical Ltd.
 /*
  *  Tests for AMF Configuration Factory
  */

--- a/factory/amf_config_test.go
+++ b/factory/amf_config_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Canonical Ltd.
+/*
+ *  Tests for AMF Configuration Factory
+ */
+
+package factory
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Webui URL is not set then default Webui URL value is returned
+func TestGetDefaultWebuiUrl(t *testing.T) {
+	if err := InitConfigFactory("../amfTest/amfcfg.yaml"); err != nil {
+		fmt.Printf("Error in InitConfigFactory: %v\n", err)
+	}
+	got := AmfConfig.Configuration.WebuiUri
+	want := "webui:9876"
+	assert.Equal(t, got, want, "The webui URL is not correct.")
+}
+
+// Webui URL is set to a custom value then custom Webui URL is returned
+func TestGetCustomWebuiUrl(t *testing.T) {
+	if err := InitConfigFactory("../amfTest/amfcfg_with_custom_webui_url.yaml"); err != nil {
+		fmt.Printf("Error in InitConfigFactory: %v\n", err)
+	}
+	got := AmfConfig.Configuration.WebuiUri
+	want := "myspecialwebui:9872"
+	assert.Equal(t, got, want, "The webui URL is not correct.")
+}


### PR DESCRIPTION
Adding unit test to validate that custom Webui URL is successfully set.