### PR TITLE
fix: create collections only when database is enabled

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -358,7 +358,7 @@ func (amf *AMF) Start() {
 	}
 
 	if self.EnableDbStore {
-		go self.SetupAmfCollection()
+		go context.SetupAmfCollection()
 	}
 
 	signalChannel := make(chan os.Signal, 1)

--- a/service/init.go
+++ b/service/init.go
@@ -357,7 +357,9 @@ func (amf *AMF) Start() {
 		go StartGrpcServer(self.SctpGrpcPort)
 	}
 
-	go context.SetupAmfCollection()
+	if self.EnableDbStore {
+		go self.SetupAmfCollection()
+	}
 
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
This PR fixes the wrong behaviour for which the AMF tries to create collections mongoDB even when the `EnableDbStore` configuration option is set to false.