### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/amfTest/amfcfg.yaml
+++ b/amfTest/amfcfg.yaml
@@ -17,8 +17,8 @@ configuration:
     bindingIPv4: 127.0.0.18  # IP used to bind the service
     port: 8000 # port used to bind the service
     tls: # the local path of TLS key
-      key: free5gc/support/TLS/amf.pem # AMF TLS Certificate
-      pem: free5gc/support/TLS/amf.pem # AMF TLS Private key
+      key: /support/TLS/amf.pem # AMF TLS Certificate
+      pem: /support/TLS/amf.pem # AMF TLS Private key
   serviceNameList: # the SBI services provided by this AMF, refer to TS 29.518
     - namf-comm # Namf_Communication service
     - namf-evts # Namf_EventExposure service

--- a/amfTest/amfcfg.yaml
+++ b/amfTest/amfcfg.yaml
@@ -16,6 +16,9 @@ configuration:
     registerIPv4: 127.0.0.18 # IP used to register to NRF
     bindingIPv4: 127.0.0.18  # IP used to bind the service
     port: 8000 # port used to bind the service
+    tls: # the local path of TLS key
+      key: free5gc/support/TLS/amf.pem # AMF TLS Certificate
+      pem: free5gc/support/TLS/amf.pem # AMF TLS Private key
   serviceNameList: # the SBI services provided by this AMF, refer to TS 29.518
     - namf-comm # Namf_Communication service
     - namf-evts # Namf_EventExposure service

--- a/context/context.go
+++ b/context/context.go
@@ -66,6 +66,8 @@ type AMFContext struct {
 	UriScheme                       models.UriScheme
 	BindingIPv4                     string
 	SBIPort                         int
+	Key                             string
+	PEM                             string
 	NgapPort                        int
 	SctpGrpcPort                    int
 	RegisterIPv4                    string

--- a/factory/config.go
+++ b/factory/config.go
@@ -156,9 +156,15 @@ type NetworkFeatureSupport5GS struct {
 
 type Sbi struct {
 	Scheme       string `yaml:"scheme"`
+	TLS          *TLS   `yaml:"tls"`
 	RegisterIPv4 string `yaml:"registerIPv4,omitempty"` // IP that is registered at NRF.
 	BindingIPv4  string `yaml:"bindingIPv4,omitempty"`  // IP used to run the server in the node.
 	Port         int    `yaml:"port,omitempty"`
+}
+
+type TLS struct {
+	PEM string `yaml:"pem,omitempty"`
+	Key string `yaml:"key,omitempty"`
 }
 
 type Security struct {

--- a/service/init.go
+++ b/service/init.go
@@ -381,10 +381,12 @@ func (amf *AMF) Start() {
 	}
 
 	serverScheme := factory.AmfConfig.Configuration.Sbi.Scheme
+	amfPemPath := path_util.Free5gcPath(factory.AmfConfig.Configuration.Sbi.TLS.PEM)
+	amfKeyPath := path_util.Free5gcPath(factory.AmfConfig.Configuration.Sbi.TLS.Key)
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(util.AmfPemPath, util.AmfKeyPath)
+		err = server.ListenAndServeTLS(amfPemPath, amfKeyPath)
 	}
 
 	if err != nil {

--- a/service/init.go
+++ b/service/init.go
@@ -381,8 +381,8 @@ func (amf *AMF) Start() {
 	}
 
 	serverScheme := factory.AmfConfig.Configuration.Sbi.Scheme
-	amfPemPath := path_util.Free5gcPath(factory.AmfConfig.Configuration.Sbi.TLS.PEM)
-	amfKeyPath := path_util.Free5gcPath(factory.AmfConfig.Configuration.Sbi.TLS.Key)
+	amfPemPath := factory.AmfConfig.Configuration.Sbi.TLS.PEM
+	amfKeyPath := factory.AmfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {

--- a/service/init.go
+++ b/service/init.go
@@ -381,12 +381,10 @@ func (amf *AMF) Start() {
 	}
 
 	serverScheme := factory.AmfConfig.Configuration.Sbi.Scheme
-	amfPemPath := factory.AmfConfig.Configuration.Sbi.TLS.PEM
-	amfKeyPath := factory.AmfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(amfPemPath, amfKeyPath)
+		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 
 	if err != nil {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -71,6 +71,10 @@ func InitAmfContext(context *context.AMFContext) {
 		if sbi.Port != 0 {
 			context.SBIPort = sbi.Port
 		}
+		if tls := sbi.TLS; tls != nil {
+			context.Key = tls.Key
+			context.PEM = tls.PEM
+		}
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)
 		if context.BindingIPv4 != "" {
 			logger.UtilLog.Info("Parsing ServerIPv4 address from ENV Variable.")

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -64,6 +64,8 @@ func InitAmfContext(context *context.AMFContext) {
 	}
 	context.RegisterIPv4 = factory.AMF_DEFAULT_IPV4 // default localhost
 	context.SBIPort = factory.AMF_DEFAULT_PORT_INT  // default port
+	context.Key = AmfKeyPath                        // default key path
+	context.PEM = AmfPemPath                        // default PEM path
 	if sbi != nil {
 		if sbi.RegisterIPv4 != "" {
 			context.RegisterIPv4 = os.Getenv("POD_IP")
@@ -72,8 +74,12 @@ func InitAmfContext(context *context.AMFContext) {
 			context.SBIPort = sbi.Port
 		}
 		if tls := sbi.TLS; tls != nil {
-			context.Key = tls.Key
-			context.PEM = tls.PEM
+			if tls.Key != "" {
+				context.Key = tls.Key
+			}
+			if tls.PEM != "" {
+				context.PEM = tls.PEM
+			}
 		}
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)
 		if context.BindingIPv4 != "" {


### PR DESCRIPTION
This PR enables to set custom paths for TLS certificate and private key.
This PR adds a `tls` container, composed of `pem` and `key` keys, inside `sbi` container to specify the paths of TLS certificate and private key to use for the HTTPS server.