### PR TITLE
AMF pod crash when Mobile data disabled and re-enabled in UE

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -1721,6 +1721,7 @@ func HandlePDUSessionResourceSetupResponse(ran *context.AmfRan, message *ngapTyp
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
 					ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+					continue
 				}
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, smContext,
 					models.N2SmInfoType_PDU_RES_SETUP_FAIL, transfer)


### PR DESCRIPTION
Issue: We have successfully connected the SD core with the OAI-gNB (usrp B210) and real UE. However, the pod crashes consistently when we disable and re-enable mobile data.

Troubleshoot: We identified the root cause of the pod crash: the Pdusessionresourcesetupresponse message contains both PDUSessionResourceSetupListSures and PDUSessionResourceFailedToSetupListSures IE's. While PDUSessionResourceSetupListSures contains the expected pduSessionId matching the one sent in the PDUSessionResourceSetupRequest, PDUSessionResourceFailedToSetupListSures contains a pduSessionId of 0, causing the pod to crash because the corresponding SmContext cannot be found.

Fix: Added continue if SmContext is not found.