### PR TITLE
N2 handover - Downlink RAN Status Transfer failure fix

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -3801,6 +3801,20 @@ func HandleUplinkRanStatusTransfer(ran *context.AmfRan, message *ngapType.NGAPPD
 		return
 	}
 	// send to T-AMF using N1N2MessageTransfer (R16)
+
+	// Send Downlink RAN Status Transfer
+	targetUe := ranUe.TargetUe
+	if targetUe != nil {
+		logger.NgapLog.Info("Target AMF UE NGAP Id: ", targetUe.AmfUeNgapId)
+		logger.NgapLog.Info("Target RAN UE NGAP Id: ", targetUe.RanUeNgapId)
+	}
+
+	if rANStatusTransferTransparentContainer != nil {
+		ngap_message.SendDownlinkRanStatusTransfer(amfUe.RanUe[models.AccessType__3_GPP_ACCESS], *rANStatusTransferTransparentContainer)
+		ngap_message.SendDownlinkRanStatusTransfer(targetUe, *rANStatusTransferTransparentContainer)
+	} else {
+		ran.Log.Error("Cannot send downlink RAN status transfer: rANStatusTransferTransparentContainer is nil")
+	}
 }
 
 func HandleNasNonDeliveryIndication(ran *context.AmfRan, message *ngapType.NGAPPDU) {


### PR DESCRIPTION
Issue:
N2 Handover failure due to SendDownlinkRanStatusTransfer() not being called after Uplink RAN Status Transfer.

Troubleshoot:
Upon investigation, it was found that the function SendDownlinkRanStatusTransfer() was not triggered, which led to the failure of the N2 handover process.

Fix:
The issue has been fixed by ensuring that SendDownlinkRanStatusTransfer() is called with the target UE after the Uplink RAN Status Transfer.