### PR TITLE
Xn Handover - AMF crash fix

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -313,6 +313,10 @@ func SendUpdateSmContextXnHandover(
 	ue *amf_context.AmfUe, smContext *amf_context.SmContext, n2SmType models.N2SmInfoType, N2SmInfo []byte) (
 	*models.UpdateSmContextResponse, *models.UpdateSmContextErrorResponse, *models.ProblemDetails, error,
 ) {
+	// Check if the smContext is nil to prevent nil pointer dereference
+	if smContext == nil {
+		return nil, nil, nil, fmt.Errorf("smContext is nil")
+	}
 	updateData := models.SmContextUpdateData{}
 	if n2SmType != "" {
 		updateData.N2SmInfoType = n2SmType


### PR DESCRIPTION
Issue:
Xn Handover failure due to AMF crashing when the gNodeB provides an incorrect PDU Session ID in the NG Path Switch Request.

Troubleshoot:
The crash was traced to the absence of a proper check for the PDU Session ID in the SendUpdateSmContextXnHandover function, causing the AMF to crash when receiving an incorrect or invalid PDU Session ID from the gNodeB.

Fix:
The issue has been resolved by adding a nil check in the SendUpdateSmContextXnHandover function.

Supporting Data:
[Xn-Handover-AMF-Crash-PCAP-Logs.zip](https://github.com/user-attachments/files/17095452/Xn-Handover-AMF-Crash-PCAP-Logs.zip)