### PR TITLE
Number of fixes in AMF to handle multiple service req

### DIFF
--- a/context/ran_ue.go
+++ b/context/ran_ue.go
@@ -93,7 +93,10 @@ func (ranUe *RanUe) Remove() error {
 		return fmt.Errorf("RanUe not found in Ran")
 	}
 	if ranUe.AmfUe != nil {
-		ranUe.AmfUe.DetachRanUe(ran.AnType)
+		amfUe := ranUe.AmfUe
+		if amfUe.RanUe[ran.AnType] == ranUe {
+			ranUe.AmfUe.DetachRanUe(ran.AnType)
+		}
 		ranUe.DetachAmfUe()
 	}
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Info          *Info          `yaml:"info"`
 	Configuration *Configuration `yaml:"configuration"`
 	Logger        *logger.Logger `yaml:"logger"`
+	Rcvd          bool
 }
 
 type Info struct {

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -119,6 +119,7 @@ func UpdateAmfConfig(f string) error {
 			logger.CfgLog.Infoln("updated T3565 ", amfConfig.Configuration.T3565)
 		}
 
+		amfConfig.Rcvd = true
 		AmfConfig = amfConfig
 	}
 	return nil

--- a/gmm/message/send.go
+++ b/gmm/message/send.go
@@ -277,6 +277,11 @@ func SendRegistrationAccept(
 		return
 	}
 
+	if ue.RanUe[anType] == nil {
+		ue.GmmLog.Error("Error in sending RegistrationAccept")
+		return
+	}
+
 	if ue.RanUe[anType].UeContextRequest {
 		ngap_message.SendInitialContextSetupRequest(ue, anType, nasMsg, pduSessionResourceSetupList, nil, nil, nil)
 	} else {

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -39,6 +39,10 @@ func FetchRanUeContext(ran *context.AmfRan, message *ngapType.NGAPPDU) (*context
 	var fiveGSTMSI *ngapType.FiveGSTMSI
 	var ranUe *context.RanUe
 
+	if !factory.AmfConfig.Rcvd {
+		logger.NgapLog.Error("AMF not ready to handle signalling traffic")
+		return nil, nil
+	}
 	if ran == nil {
 		logger.NgapLog.Error("ran is nil")
 		return nil, nil
@@ -1385,6 +1389,11 @@ func HandleInitialUEMessage(ran *context.AmfRan, message *ngapType.NGAPPDU, sctp
 	// var allowedNSSAI *ngapType.AllowedNSSAI
 
 	var iesCriticalityDiagnostics ngapType.CriticalityDiagnosticsIEList
+
+	if !factory.AmfConfig.Rcvd {
+		logger.NgapLog.Error("AMF not ready to handle signalling traffic")
+		return
+	}
 
 	if message == nil {
 		ran.Log.Error("NGAP Message is nil")

--- a/service/init.go
+++ b/service/init.go
@@ -712,6 +712,7 @@ func (amf *AMF) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 		if len(factory.AmfConfig.Configuration.ServedGumaiList) > 0 {
 			RocUpdateConfigChannel <- true
 		}
+		factory.AmfConfig.Rcvd = true
 	}
 	return true
 }


### PR DESCRIPTION
1. UE Context Release handling leads to total 3 messages. Final message is UE Context Release Complete is sent by gNB. Service request was reaching AMF before UE Context Release Complete and this leads to crash, since UE to RAN-UE linking gets removed while processing Complete message. Added necessary protection to fix the crash

2. Other fixes involve AMF should not handle the new calls if it has not yet received any config else AMF crashes due to no config