### PR TITLE
ngKSI already in use - Bug Fix

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1558,6 +1558,12 @@ func AuthenticationProcedure(ue *context.AmfUe, accessType models.AccessType) (b
 	ue.AuthenticationCtx = response
 	ue.ABBA = []uint8{0x00, 0x00} // set ABBA value as described at TS 33.501 Annex A.7.1
 
+	// As per the Specification 33.501 - 6.2.3.2 Key identification
+	if ue.NgKsi.Tsc == models.ScType_NATIVE {
+		ue.NgKsi.Ksi = (ue.NgKsi.Ksi + 1) % 7
+	}
+	ue.GmmLog.Infoln("ngKSI after 5G-AKA:", ue.NgKsi.Ksi)
+
 	gmm_message.SendAuthenticationRequest(ue.RanUe[accessType])
 	return false, nil
 }


### PR DESCRIPTION
Issue:
Authentication failure due to duplicate ngKSI values

Troubleshoot:
Troubleshooting revealed that the Core includes the same ngKSI value from Registration Request in Authentication Request.

Fix:
Updated ngKSI value after 5G AKA procedure.

Original PR - https://github.com/omec-project/amf/pull/307  closed due to local repo issues and current new PR is opened after addressing comments.