### PR TITLE
fix: check if a message read from channel to prevent nil pointer dereference

### DIFF
--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -590,7 +590,10 @@ func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwr
 	var ueRegStatusUpdateRspData *models.UeRegStatusUpdateRspData
 	ue.EventChannel.UpdateSbiHandler(UeContextHandler)
 	ue.EventChannel.SubmitMessage(sbiMsg)
-	msg := <-sbiMsg.Result
+	msg, read := <-sbiMsg.Result
+	if !read {
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
+	}
 	if msg.RespData != nil {
 		ueRegStatusUpdateRspData = msg.RespData.(*models.UeRegStatusUpdateRspData)
 	}


### PR DESCRIPTION
Aims to fix https://github.com/canonical/sdcore-amf-k8s-operator/issues/472

Invalid memory address or nil pointer dereference error occurs when producer.HandleRegistrationStatusUpdateRequest is called
(producer/ue_context.go:599).  This PR first checks if a message is read through the channel before proceeding with response data and problem details.