### PR TITLE
fix: potential problems that may cause a panic during context setup

### DIFF
--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -369,9 +369,17 @@ func SecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	switch event {
 	case fsm.EntryEvent:
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			return
+		}
 		gmmMessage := args[ArgNASMessage]
-		accessType := args[ArgAccessType].(models.AccessType)
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.GmmLog.Debugln("EntryEvent at GMM State[ContextSetup]")
 		amfUe.PublishUeCtxtInfo()
 		switch message := gmmMessage.(type) {
@@ -397,9 +405,21 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 			logger.GmmLog.Errorf("UE state mismatch: receieve wrong gmm message")
 		}
 	case GmmMessageEvent:
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
-		gmmMessage := args[ArgNASMessage].(*nas.GmmMessage)
-		accessType := args[ArgAccessType].(models.AccessType)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			return
+		}
+		gmmMessage, ok := args[ArgNASMessage].(*nas.GmmMessage)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgNASMessage")
+			return
+		}
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.GmmLog.Debugln("GmmMessageEvent at GMM State[ContextSetup]")
 		switch gmmMessage.GetMessageType() {
 		case nas.MsgTypeIdentityResponse:
@@ -448,8 +468,16 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		logger.GmmLog.Debugln(event)
 	case NwInitiatedDeregistrationEvent:
 		logger.GmmLog.Debugln(event)
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
-		accessType := args[ArgAccessType].(models.AccessType)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			return
+		}
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.T3550.Stop()
 		amfUe.T3550 = nil
 		amfUe.State[accessType].Set(context.Registered)

--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -371,13 +371,13 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	case fsm.EntryEvent:
 		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
 			return
 		}
 		gmmMessage := args[ArgNASMessage]
 		accessType, ok := args[ArgAccessType].(models.AccessType)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
 			return
 		}
 		amfUe.GmmLog.Debugln("EntryEvent at GMM State[ContextSetup]")
@@ -407,17 +407,17 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	case GmmMessageEvent:
 		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
 			return
 		}
 		gmmMessage, ok := args[ArgNASMessage].(*nas.GmmMessage)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgNASMessage")
+			logger.GmmLog.Errorln("invalid type assertion for ArgNASMessage")
 			return
 		}
 		accessType, ok := args[ArgAccessType].(models.AccessType)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
 			return
 		}
 		amfUe.GmmLog.Debugln("GmmMessageEvent at GMM State[ContextSetup]")
@@ -470,12 +470,12 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		logger.GmmLog.Debugln(event)
 		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAmfUe")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
 			return
 		}
 		accessType, ok := args[ArgAccessType].(models.AccessType)
 		if !ok {
-			logger.GmmLog.Errorln("Invalid type assertion for ArgAccessType")
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
 			return
 		}
 		amfUe.T3550.Stop()

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -611,14 +611,14 @@ func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwr
 			if problemDetails, ok := msg.ProblemDetails.(*models.ProblemDetails); ok {
 				return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 			}
-		} else {
-			// Handle unexpected response data type
-			problemDetails := &models.ProblemDetails{
-				Status: http.StatusInternalServerError,
-				Cause:  "UNEXPECTED_RESPONSE_TYPE",
-			}
-			return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 		}
+		// Handle unexpected response data type
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Cause:  "UNEXPECTED_RESPONSE_TYPE",
+		}
+		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
+
 	}
 	return httpwrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
 }

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -618,7 +618,6 @@ func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwr
 			Cause:  "UNEXPECTED_RESPONSE_TYPE",
 		}
 		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
-
 	}
 	return httpwrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
 }


### PR DESCRIPTION
Aiming to fix any potential issue that causes: https://github.com/canonical/sdcore-amf-k8s-operator/issues/472
I am not able to reproduce the problem. But, this PR aiming to fix potential issues in the `HandleRegistrationStatusUpdateRequest` and `ContextSetup` functions.

- Safely Handle Type Assertions
- Handle unexpected response data types
- Check if  message retrieved from channel and handle if no message retrieved situation
- Check the message format and handle wrong message format