### PR TITLE
fix: potential problems that may cause a panic during context setup

### DIFF
--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -369,9 +369,17 @@ func SecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 	switch event {
 	case fsm.EntryEvent:
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
+			return
+		}
 		gmmMessage := args[ArgNASMessage]
-		accessType := args[ArgAccessType].(models.AccessType)
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.GmmLog.Debugln("EntryEvent at GMM State[ContextSetup]")
 		amfUe.PublishUeCtxtInfo()
 		switch message := gmmMessage.(type) {
@@ -397,9 +405,21 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 			logger.GmmLog.Errorf("UE state mismatch: receieve wrong gmm message")
 		}
 	case GmmMessageEvent:
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
-		gmmMessage := args[ArgNASMessage].(*nas.GmmMessage)
-		accessType := args[ArgAccessType].(models.AccessType)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
+			return
+		}
+		gmmMessage, ok := args[ArgNASMessage].(*nas.GmmMessage)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgNASMessage")
+			return
+		}
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.GmmLog.Debugln("GmmMessageEvent at GMM State[ContextSetup]")
 		switch gmmMessage.GetMessageType() {
 		case nas.MsgTypeIdentityResponse:
@@ -448,8 +468,16 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		logger.GmmLog.Debugln(event)
 	case NwInitiatedDeregistrationEvent:
 		logger.GmmLog.Debugln(event)
-		amfUe := args[ArgAmfUe].(*context.AmfUe)
-		accessType := args[ArgAccessType].(models.AccessType)
+		amfUe, ok := args[ArgAmfUe].(*context.AmfUe)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAmfUe")
+			return
+		}
+		accessType, ok := args[ArgAccessType].(models.AccessType)
+		if !ok {
+			logger.GmmLog.Errorln("invalid type assertion for ArgAccessType")
+			return
+		}
 		amfUe.T3550.Stop()
 		amfUe.T3550 = nil
 		amfUe.State[accessType].Set(context.Registered)

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -564,11 +564,18 @@ func AssignEbiDataProcedure(ueContextID string, assignEbiData models.AssignEbiDa
 	}
 }
 
-// TS 29.518 5.2.2.2.2
+// HandleRegistrationStatusUpdateRequest TS 29.518 5.2.2.2.2
 func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CommLog.Info("Handle Registration Status Update Request")
 
-	ueRegStatusUpdateReqData := request.Body.(models.UeRegStatusUpdateReqData)
+	ueRegStatusUpdateReqData, ok := request.Body.(models.UeRegStatusUpdateReqData)
+	if !ok {
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusBadRequest,
+			Cause:  "INVALID_BODY_FORMAT",
+		}
+		return httpwrapper.NewResponse(http.StatusBadRequest, nil, problemDetails)
+	}
 	ueContextID := request.Params["ueContextId"]
 
 	amfSelf := context.AMF_Self()
@@ -579,7 +586,7 @@ func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwr
 			Status: http.StatusNotFound,
 			Cause:  "CONTEXT_NOT_FOUND",
 		}
-		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, problemDetails)
 	}
 	sbiMsg := context.SbiMsg{
 		UeContextId: ueContextID,
@@ -590,16 +597,29 @@ func HandleRegistrationStatusUpdateRequest(request *httpwrapper.Request) *httpwr
 	var ueRegStatusUpdateRspData *models.UeRegStatusUpdateRspData
 	ue.EventChannel.UpdateSbiHandler(UeContextHandler)
 	ue.EventChannel.SubmitMessage(sbiMsg)
-	msg := <-sbiMsg.Result
-	if msg.RespData != nil {
-		ueRegStatusUpdateRspData = msg.RespData.(*models.UeRegStatusUpdateRspData)
+	msg, read := <-sbiMsg.Result
+	if !read {
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusNoContent,
+			Cause:  "MESSAGE_NOT_RECEIVED",
+		}
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, problemDetails)
 	}
-	// ueRegStatusUpdateRspData, problemDetails := RegistrationStatusUpdateProcedure(ueContextID, ueRegStatusUpdateReqData)
-	if msg.ProblemDetails != nil {
-		return httpwrapper.NewResponse(int(msg.ProblemDetails.(*models.ProblemDetails).Status), nil, msg.ProblemDetails.(*models.ProblemDetails))
-	} else {
-		return httpwrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
+	ueRegStatusUpdateRspData, ok = msg.RespData.(*models.UeRegStatusUpdateRspData)
+	if !ok {
+		if msg.ProblemDetails != nil {
+			if problemDetails, ok := msg.ProblemDetails.(*models.ProblemDetails); ok {
+				return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+			}
+		}
+		// Handle unexpected response data type
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Cause:  "UNEXPECTED_RESPONSE_TYPE",
+		}
+		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 	}
+	return httpwrapper.NewResponse(http.StatusOK, nil, ueRegStatusUpdateRspData)
 }
 
 func RegistrationStatusUpdateProcedure(ueContextID string, ueRegStatusUpdateReqData models.UeRegStatusUpdateReqData) (


### PR DESCRIPTION
Aiming to fix any potential issue that causes: https://github.com/canonical/sdcore-amf-k8s-operator/issues/472
I am not able to reproduce the problem. But, this PR aiming to fix potential issues in the `HandleRegistrationStatusUpdateRequest` and `ContextSetup` functions.

- Safely Handle Type Assertions
- Handle unexpected response data types
- Check if  message retrieved from channel and handle if no message retrieved situation
- Check the message format and handle wrong message format