### PR TITLE
Fix AMF crash

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -2469,7 +2469,8 @@ func HandleInitialContextSetupFailure(ran *context.AmfRan, message *ngapType.NGA
 			transfer := item.PDUSessionResourceSetupUnsuccessfulTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found. No need to send UpdateSmContext message to SMF", pduSessionID)
+				continue
 			}
 			_, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, smContext,
 				models.N2SmInfoType_PDU_RES_SETUP_FAIL, transfer)


### PR DESCRIPTION
AMF sent Initial Context Setup message to gNB, but before gNB initiated context release while context setup was in-progress. This leads to PDU session release and later when Initial Context Setup failure is received from the gNodeB, amf failed to find pdu-session.

its wise to just process initial context setup failure message at AMF & skip processing which sends message towards SMF.