### PR TITLE
UE connection fails due to state mismatch issue

### DIFF
--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -216,6 +216,16 @@ func Authentication(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		default:
 			logger.GmmLog.Errorf("UE state mismatch: receieve gmm message[message type 0x%0x] at %s state",
 				gmmMessage.GetMessageType(), state.Current())
+			// called SendEvent() to move to deregistered state if state mismatch occurs
+			err := GmmFSM.SendEvent(state, AuthFailEvent, fsm.ArgsType{
+				ArgAmfUe:      amfUe,
+				ArgAccessType: accessType,
+			})
+			if err != nil {
+				logger.GmmLog.Errorln(err)
+			} else {
+				amfUe.GmmLog.Info("state reset to Deregistered")
+			}
 		}
 	case AuthSuccessEvent:
 		logger.GmmLog.Debugln(event)
@@ -337,6 +347,16 @@ func SecurityMode(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		default:
 			amfUe.GmmLog.Errorf("state mismatch: receieve gmm message[message type 0x%0x] at %s state",
 				gmmMessage.GetMessageType(), state.Current())
+			// called SendEvent() to move to deregistered state if state mismatch occurs
+			err := GmmFSM.SendEvent(state, SecurityModeFailEvent, fsm.ArgsType{
+				ArgAmfUe:      amfUe,
+				ArgAccessType: accessType,
+			})
+			if err != nil {
+				logger.GmmLog.Errorln(err)
+			} else {
+				amfUe.GmmLog.Info("state reset to Deregistered")
+			}
 		}
 	case SecurityModeAbortEvent:
 		logger.GmmLog.Debugln(event)
@@ -463,6 +483,19 @@ func ContextSetup(state *fsm.State, event fsm.EventType, args fsm.ArgsType) {
 		default:
 			amfUe.GmmLog.Errorf("state mismatch: receieve gmm message[message type 0x%0x] at %s state",
 				gmmMessage.GetMessageType(), state.Current())
+			msgType := gmmMessage.GetMessageType()
+			if msgType == nas.MsgTypeRegistrationRequest {
+				// called SendEvent() to move to deregistered state if state mismatch occurs
+				err := GmmFSM.SendEvent(state, ContextSetupFailEvent, fsm.ArgsType{
+					ArgAmfUe:      amfUe,
+					ArgAccessType: accessType,
+				})
+				if err != nil {
+					logger.GmmLog.Errorln(err)
+				} else {
+					amfUe.GmmLog.Info("state reset to Deregistered")
+				}
+			}
 		}
 	case ContextSetupSuccessEvent:
 		logger.GmmLog.Debugln(event)
@@ -523,6 +556,16 @@ func DeregisteredInitiated(state *fsm.State, event fsm.EventType, args fsm.ArgsT
 		default:
 			amfUe.GmmLog.Errorf("state mismatch: receieve gmm message[message type 0x%0x] at %s state",
 				gmmMessage.GetMessageType(), state.Current())
+			// called SendEvent() to move to deregistered state if state mismatch occurs
+			err := GmmFSM.SendEvent(state, DeregistrationAcceptEvent, fsm.ArgsType{
+				ArgAmfUe:      amfUe,
+				ArgAccessType: accessType,
+			})
+			if err != nil {
+				logger.GmmLog.Errorln(err)
+			} else {
+				amfUe.GmmLog.Info("state reset to Deregistered")
+			}
 		}
 	case DeregistrationAcceptEvent:
 		amfUe := args[ArgAmfUe].(*context.AmfUe)


### PR DESCRIPTION
Issue:
When an abnormal UE exit occurs, the core network state remains unchanged, preventing subsequent UE registrations and sometimes leads to AMF pod crash.

Fix:
Invoked SendEvent() to move to deregistered state in case of a state mismatch.
Applied the fix to all scenarios where a state mismatch occurs.


Supporting Data:
[amfcrash (3).zip](https://github.com/user-attachments/files/18868364/amfcrash.3.zip)


