### PR TITLE
chore: run E2E tests automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       branch_name: ${{ github.ref }}
 
   e2e-tests:
+    if: github.event_name == 'pull_request'
     uses: omec-project/.github/.github/workflows/e2e-test.yml@main
     with:
       branch_name: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,8 @@ jobs:
     uses: omec-project/.github/.github/workflows/unit-test.yml@main
     with:
       branch_name: ${{ github.ref }}
+
+  e2e-tests:
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@main
+    with:
+      branch_name: ${{ github.ref }}


### PR DESCRIPTION
Run E2E tests for pull requests as part of CI process. Hence, we make sure that integrations tests will pass without manual testing.