### PR TITLE
Issue in Xn Ping Pong Test (in B->A handover case) 

### DIFF
--- a/ngap/dispatcher.go
+++ b/ngap/dispatcher.go
@@ -148,8 +148,13 @@ func Dispatch(conn net.Conn, msg []byte) {
 			NgapMsg:   pdu,
 			SctplbMsg: nil,
 		}
-
-		ranUe.Ran.Conn = conn
+		if ranUe.Ran.GnbId == ran.GnbId {
+			ranUe.AmfUe.TxLog.Infoln("gnbid match")
+			ranUe.Ran.Conn = conn
+		} else {
+			ranUe.AmfUe.TxLog.Infoln("gnbid differ")
+			ranUe.AmfUe.TxLog.Infof("In case of Xn handover source RAN gNB id:%s, target RAN gNB id:%s", ranUe.Ran.GnbId, ran.GnbId)
+		}
 		ranUe.AmfUe.EventChannel.SubmitMessage(ngapMsg)
 	} else {
 		go DispatchNgapMsg(ran, pdu, nil)


### PR DESCRIPTION
Issue:
In the first Xn handover from A->B, the Pathswitch request is going from the Target with its IP address, and the Pathswitch request acknowledge is coming from AMF to the Target gNB properly. The issue is particularly in B->A Xn handover case, where The Pathswitch request is going from the Target with its IP address, but the Pathswitch request acknowledge is coming from AMF to the Source gNB.

Troubleshoot:
The source gNB’s remote address was wrongly set to the target’s. This causes no problem for A→B. ACKs still reach B. But in B→A, ACKs go to the wrong address (A), causing the issue.

Fix:
Incorporated gnbid in the Ran connection update in the Dispatch()

Supporting Data:
[Xn-Ping-Pong-Test.zip](https://github.com/user-attachments/files/21255056/Xn-Ping-Pong-Test.zip)
