### PR TITLE
fix: remove potential panic in SupportDnnLists

### DIFF
--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -85,10 +85,10 @@ func (ran *AmfRan) Remove() {
 	ran.RemoveAllUeInRan()
 	if AMF_Self().EnableSctpLb {
 		if ran.GnbId != "" {
-			AMF_Self().DeleteAmfRanId(ran.GnbId)
+			AMF_Self().deleteAmfRanId(ran.GnbId)
 		}
 	} else {
-		AMF_Self().DeleteAmfRan(ran.Conn)
+		AMF_Self().deleteAmfRan(ran.Conn)
 	}
 }
 

--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -85,10 +85,10 @@ func (ran *AmfRan) Remove() {
 	ran.RemoveAllUeInRan()
 	if AMF_Self().EnableSctpLb {
 		if ran.GnbId != "" {
-			AMF_Self().deleteAmfRanId(ran.GnbId)
+			AMF_Self().DeleteAmfRanId(ran.GnbId)
 		}
 	} else {
-		AMF_Self().deleteAmfRan(ran.Conn)
+		AMF_Self().DeleteAmfRan(ran.Conn)
 	}
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -439,11 +439,11 @@ func (context *AMFContext) AmfRanFindByRanID(ranNodeID models.GlobalRanNodeId) (
 	return ran, ok
 }
 
-func (context *AMFContext) deleteAmfRan(conn net.Conn) {
+func (context *AMFContext) DeleteAmfRan(conn net.Conn) {
 	context.AmfRanPool.Delete(conn)
 }
 
-func (context *AMFContext) deleteAmfRanId(gnbId string) {
+func (context *AMFContext) DeleteAmfRanId(gnbId string) {
 	context.AmfRanPool.Delete(gnbId)
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -439,21 +439,12 @@ func (context *AMFContext) AmfRanFindByRanID(ranNodeID models.GlobalRanNodeId) (
 	return ran, ok
 }
 
-func (context *AMFContext) DeleteAmfRan(conn net.Conn) {
+func (context *AMFContext) deleteAmfRan(conn net.Conn) {
 	context.AmfRanPool.Delete(conn)
 }
 
-func (context *AMFContext) DeleteAmfRanId(gnbId string) {
+func (context *AMFContext) deleteAmfRanId(gnbId string) {
 	context.AmfRanPool.Delete(gnbId)
-}
-
-func (context *AMFContext) InSupportDnnList(targetDnn string) bool {
-	for _, dnn := range context.SupportDnnLists {
-		if dnn == targetDnn {
-			return true
-		}
-	}
-	return false
 }
 
 func (context *AMFContext) InPlmnSupportList(snssai models.Snssai) bool {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -234,7 +234,7 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 							for _, dnnInfo := range snssaiInfo.DnnInfos {
 								if dnnInfo.DefaultDnnIndicator {
 									dnn = dnnInfo.Dnn
-									break
+									//break
 								}
 							}
 						}
@@ -247,7 +247,7 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 							dnn = defaultDnn
 						}
 					}
-					ue.GmmLog.Warnf("Subscription context obtained from UDM does not contain the default DNN, using %s", dnn)
+					ue.GmmLog.Warnf("Subscription context obtained from UDM does not contain the DNN, using %s", dnn)
 				}
 
 				if newSmContext, cause, err := consumer.SelectSmf(ctx, ue, anType, pduSessionID, snssai, dnn); err != nil {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -226,7 +226,6 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 				} else {
 					// if user's subscription context obtained from UDM does not contain the default DNN for the,
 					// S-NSSAI, the AMF shall use a locally configured DNN as the DNN
-					dnn = ue.ServingAMF.SupportDnnLists[0]
 
 					if ue.SmfSelectionData != nil {
 						snssaiStr := util.SnssaiModelsToHex(snssai)
@@ -234,10 +233,20 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 							for _, dnnInfo := range snssaiInfo.DnnInfos {
 								if dnnInfo.DefaultDnnIndicator {
 									dnn = dnnInfo.Dnn
+									break
 								}
 							}
 						}
 					}
+
+					if dnn == "" {
+						if len(ue.ServingAMF.SupportDnnLists) > 0 {
+							dnn = ue.ServingAMF.SupportDnnLists[0]
+						} else {
+							dnn = "internet"
+						}
+					}
+					ue.GmmLog.Warnf("Subscription context obtained from UDM does not contain the default DNN, using %s", dnn)
 				}
 
 				if newSmContext, cause, err := consumer.SelectSmf(ctx, ue, anType, pduSessionID, snssai, dnn); err != nil {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -234,7 +234,7 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 							for _, dnnInfo := range snssaiInfo.DnnInfos {
 								if dnnInfo.DefaultDnnIndicator {
 									dnn = dnnInfo.Dnn
-									//break
+									break
 								}
 							}
 						}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -46,6 +46,7 @@ const (
 	DNN_CONGESTION            = "DNN_CONGESTION"
 	PRIORITIZED_SERVICES_ONLY = "PRIORITIZED_SERVICES_ONLY"
 	OUT_OF_LADN_SERVICE_AREA  = "OUT_OF_LADN_SERVICE_AREA"
+	defaultDnn                = "internet"
 )
 
 func HandleULNASTransport(ctx ctxt.Context, ue *context.AmfUe, anType models.AccessType,
@@ -243,7 +244,7 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 						if len(ue.ServingAMF.SupportDnnLists) > 0 {
 							dnn = ue.ServingAMF.SupportDnnLists[0]
 						} else {
-							dnn = "internet"
+							dnn = defaultDnn
 						}
 					}
 					ue.GmmLog.Warnf("Subscription context obtained from UDM does not contain the default DNN, using %s", dnn)


### PR DESCRIPTION
## Description 

If `SupportDnnLists` is not set in the configuration file, there is a potential panic in the code.

If the UE's subscription obtained from the UDM does not contain the default DNN, the AMF willl try to get it from the `ue.SmfSelectionData`. If not found, the AMF will get the DNN from `SupportDnnLists`. If `SupportDnnLists` is empty, it will fallback to "internet" as done in [producer/callback.go](https://github.com/omec-project/amf/blob/d8dd0d93707be1f3b81f0ddf6e9eba941e15dec3/producer/callback.go#L155C7-L155C15)