### PR TITLE
fix: properly shutdown tracer

### DIFF
--- a/service/amf_server.go
+++ b/service/amf_server.go
@@ -6,11 +6,12 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 
-	"github.com/omec-project/amf/context"
+	amfContext "github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/factory"
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/metrics"
@@ -52,8 +53,8 @@ func (s *Server) HandleMessage(srv sdcoreAmfServer.NgapService_HandleMessageServ
 				rsp.Msgtype = sdcoreAmfServer.MsgType_INIT_MSG
 				rsp.AmfId = os.Getenv("HOSTNAME")
 				logger.GrpcLog.Debugf("send Response message body from client (%s): Verbose - %s, MsgType %v", rsp.AmfId, rsp.VerboseMsg, rsp.Msgtype)
-				amfSelf := context.AMF_Self()
-				var ran *context.AmfRan
+				amfSelf := amfContext.AMF_Self()
+				var ran *amfContext.AmfRan
 				var ok bool
 				if ran, ok = amfSelf.AmfRanFindByGnbId(req.GnbId); !ok {
 					ran = amfSelf.NewAmfRanId(req.GnbId)
@@ -122,10 +123,11 @@ func (s *Server) HandleMessage(srv sdcoreAmfServer.NgapService_HandleMessageServ
 	return nil
 }
 
-func StartGrpcServer(port int) {
+func StartGrpcServer(ctx context.Context, port int) {
 	endpt := fmt.Sprintf(":%d", port)
 	fmt.Println("listen - ", endpt)
-	lis, err := net.Listen("tcp", endpt)
+	lisCfg := net.ListenConfig{}
+	lis, err := lisCfg.Listen(ctx, "tcp", endpt)
 	if err != nil {
 		logger.GrpcLog.Errorf("failed to listen: %v", err)
 	}

--- a/service/init.go
+++ b/service/init.go
@@ -62,10 +62,7 @@ type AMF struct{}
 
 const IMSI_PREFIX = "imsi-"
 
-var (
-	RocUpdateConfigChannel chan bool
-	tracerProvider         *sdktrace.TracerProvider
-)
+var RocUpdateConfigChannel chan bool
 
 type (
 	// Config information.
@@ -408,11 +405,13 @@ func (amf *AMF) Start() {
 		go context.SetupAmfCollection()
 	}
 
+	var tracerProvider *sdktrace.TracerProvider
+
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-signalChannel
-		amf.Terminate()
+		amf.Terminate(tracerProvider)
 		os.Exit(0)
 	}()
 
@@ -462,7 +461,7 @@ func (amf *AMF) Exec(c *cli.Command) error {
 }
 
 // Used in AMF planned removal procedure
-func (amf *AMF) Terminate() {
+func (amf *AMF) Terminate(tracerProvider *sdktrace.TracerProvider) {
 	logger.InitLog.Infoln("terminating AMF")
 	amfSelf := context.AMF_Self()
 


### PR DESCRIPTION
This PR fixes the shutdown of the tracer introduced in #473.
When an interrupt or SIGTERM are provided, deferred functions are not called.
This PR moves the shutdown of the tracer in the `Terminate` function, so that it can be properly handled.