### PR TITLE
Add codeowners as suggested by openSSF scorecard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+* @omec-project/5gc-maintainers


### PR DESCRIPTION
Fixes https://github.com/omec-project/amf/security/code-scanning/21