### PR TITLE
Fix race condition issue when running unit-tests

### DIFF
--- a/nfregistration/nf_registration_test.go
+++ b/nfregistration/nf_registration_test.go
@@ -40,6 +40,12 @@ func currentKeepAliveTimer() *time.Timer {
 	return keepAliveTimer
 }
 
+func cleanupNfRegistrationService(t *testing.T, cancel context.CancelFunc, serviceDone <-chan struct{}) {
+	t.Helper()
+	cancel()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
+}
+
 func TestNfRegistrationService_WhenEmptyConfig_ThenDeregisterNFAndStopTimer(t *testing.T) {
 	isDeregisterNFCalled := false
 	testCases := []struct {
@@ -115,13 +121,13 @@ func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTi
 	keepAliveTimer = nil
 	originalSendRegisterNFInstance := consumer.SendRegisterNFInstance
 	originalRegisterNF := registerNF
-	defer func() {
+	t.Cleanup(func() {
 		consumer.SendRegisterNFInstance = originalSendRegisterNFInstance
 		registerNF = originalRegisterNF
 		if keepAliveTimer != nil {
 			keepAliveTimer.Stop()
 		}
-	}()
+	})
 
 	registrations := []nfConfigApi.AccessAndMobility{}
 	var registrationsMu sync.Mutex
@@ -146,6 +152,9 @@ func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTi
 		defer close(serviceDone)
 		StartNfRegistrationService(ctx, ch)
 	}()
+	t.Cleanup(func() {
+		cleanupNfRegistrationService(t, cancel, serviceDone)
+	})
 	newConfig := []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -156,8 +165,6 @@ func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTi
 	ch <- newConfig
 
 	waitForSignal(t, registerDone, time.Second, "timed out waiting for NF registration to complete")
-	cancel()
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
 
 	if currentKeepAliveTimer() == nil {
 		t.Errorf("expected keepAliveTimer to be initialized by startKeepAliveTimer")
@@ -172,13 +179,13 @@ func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTi
 func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T) {
 	originalSendRegisterNFInstance := consumer.SendRegisterNFInstance
 	originalRegisterNF := registerNF
-	defer func() {
+	t.Cleanup(func() {
 		consumer.SendRegisterNFInstance = originalSendRegisterNFInstance
 		registerNF = originalRegisterNF
 		if keepAliveTimer != nil {
 			keepAliveTimer.Stop()
 		}
-	}()
+	})
 
 	var called atomic.Int32
 	registerAttempts := make(chan struct{}, 2)
@@ -201,11 +208,15 @@ func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T
 	ch := make(chan []nfConfigApi.AccessAndMobility, 1)
 	ctx, cancel := context.WithCancel(t.Context())
 	serviceDone := make(chan struct{})
-	defer cancel()
 	go func() {
 		defer close(serviceDone)
 		StartNfRegistrationService(ctx, ch)
 	}()
+	t.Cleanup(func() {
+		cancel()
+		waitForSignal(t, registerDone, time.Second, "timed out waiting for register loop to stop")
+		waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
+	})
 	ch <- []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -216,9 +227,6 @@ func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T
 
 	waitForSignal(t, registerAttempts, retryTime+time.Second, "timed out waiting for first register attempt")
 	waitForSignal(t, registerAttempts, retryTime+time.Second, "timed out waiting for retry register attempt")
-	cancel()
-	waitForSignal(t, registerDone, time.Second, "timed out waiting for register loop to stop")
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
 
 	if called.Load() < 2 {
 		t.Errorf("expected to retry register to NRF")
@@ -228,12 +236,12 @@ func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T
 
 func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCancelled(t *testing.T) {
 	originalRegisterNf := registerNF
-	defer func() {
+	t.Cleanup(func() {
 		registerNF = originalRegisterNf
 		if keepAliveTimer != nil {
 			keepAliveTimer.Stop()
 		}
-	}()
+	})
 
 	var registrationsMu sync.Mutex
 	var registrations []struct {
@@ -255,11 +263,13 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 	ch := make(chan []nfConfigApi.AccessAndMobility, 1)
 	ctx, cancel := context.WithCancel(t.Context())
 	serviceDone := make(chan struct{})
-	defer cancel()
 	go func() {
 		defer close(serviceDone)
 		StartNfRegistrationService(ctx, ch)
 	}()
+	t.Cleanup(func() {
+		cleanupNfRegistrationService(t, cancel, serviceDone)
+	})
 	firstConfig := []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -311,9 +321,6 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 		t.Errorf("expected %+v config, received %+v", secondConfig, registrations)
 	}
 	registrationsMu.Unlock()
-
-	cancel()
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
 }
 
 func TestHeartbeatNF_Success(t *testing.T) {

--- a/nfregistration/nf_registration_test.go
+++ b/nfregistration/nf_registration_test.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +21,24 @@ import (
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/openapi/nfConfigApi"
 )
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, timeout time.Duration, message string) {
+	t.Helper()
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	select {
+	case <-signal:
+	case <-timeoutTimer.C:
+		t.Fatal(message)
+	}
+}
+
+func currentKeepAliveTimer() *time.Timer {
+	keepAliveTimerMutex.Lock()
+	defer keepAliveTimerMutex.Unlock()
+	return keepAliveTimer
+}
 
 func TestNfRegistrationService_WhenEmptyConfig_ThenDeregisterNFAndStopTimer(t *testing.T) {
 	isDeregisterNFCalled := false
@@ -63,10 +83,20 @@ func TestNfRegistrationService_WhenEmptyConfig_ThenDeregisterNFAndStopTimer(t *t
 
 			ch := make(chan []nfConfigApi.AccessAndMobility, 1)
 			ctx := t.Context()
-			go StartNfRegistrationService(ctx, ch)
+			serviceDone := make(chan struct{})
+			go func() {
+				defer close(serviceDone)
+				StartNfRegistrationService(ctx, ch)
+			}()
 			ch <- []nfConfigApi.AccessAndMobility{}
+			timeoutTimer := time.NewTimer(1 * time.Second)
+			defer timeoutTimer.Stop()
 
-			time.Sleep(100 * time.Millisecond)
+			select {
+			case <-serviceDone:
+			case <-timeoutTimer.C:
+				t.Fatal("timed out waiting for NF registration service to stop")
+			}
 
 			if keepAliveTimer != nil {
 				t.Errorf("expected keepAliveTimer to be nil after stopKeepAliveTimer")
@@ -84,23 +114,38 @@ func TestNfRegistrationService_WhenEmptyConfig_ThenDeregisterNFAndStopTimer(t *t
 func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTimer(t *testing.T) {
 	keepAliveTimer = nil
 	originalSendRegisterNFInstance := consumer.SendRegisterNFInstance
+	originalRegisterNF := registerNF
 	defer func() {
 		consumer.SendRegisterNFInstance = originalSendRegisterNFInstance
+		registerNF = originalRegisterNF
 		if keepAliveTimer != nil {
 			keepAliveTimer.Stop()
 		}
 	}()
 
 	registrations := []nfConfigApi.AccessAndMobility{}
+	var registrationsMu sync.Mutex
+	registerDone := make(chan struct{})
+	var registerDoneOnce sync.Once
 	consumer.SendRegisterNFInstance = func(ctx context.Context, accessAndMobilityConfig []nfConfigApi.AccessAndMobility) (models.NfProfile, string, error) {
 		profile := models.NfProfile{HeartBeatTimer: 60}
+		registrationsMu.Lock()
 		registrations = append(registrations, accessAndMobilityConfig...)
+		registrationsMu.Unlock()
 		return profile, "", nil
+	}
+	registerNF = func(registerCtx context.Context, newAccessAndMobilityConfig []nfConfigApi.AccessAndMobility) {
+		defer registerDoneOnce.Do(func() { close(registerDone) })
+		originalRegisterNF(registerCtx, newAccessAndMobilityConfig)
 	}
 
 	ch := make(chan []nfConfigApi.AccessAndMobility, 1)
-	ctx := t.Context()
-	go StartNfRegistrationService(ctx, ch)
+	ctx, cancel := context.WithCancel(t.Context())
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		StartNfRegistrationService(ctx, ch)
+	}()
 	newConfig := []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -110,34 +155,57 @@ func TestNfRegistrationService_WhenConfigChanged_ThenRegisterNFSuccessAndStartTi
 	}
 	ch <- newConfig
 
-	time.Sleep(100 * time.Millisecond)
-	if keepAliveTimer == nil {
+	waitForSignal(t, registerDone, time.Second, "timed out waiting for NF registration to complete")
+	cancel()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
+
+	if currentKeepAliveTimer() == nil {
 		t.Errorf("expected keepAliveTimer to be initialized by startKeepAliveTimer")
 	}
+	registrationsMu.Lock()
 	if !reflect.DeepEqual(registrations, newConfig) {
 		t.Errorf("expected %+v config, received %+v", newConfig, registrations)
 	}
+	registrationsMu.Unlock()
 }
 
 func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T) {
 	originalSendRegisterNFInstance := consumer.SendRegisterNFInstance
+	originalRegisterNF := registerNF
 	defer func() {
 		consumer.SendRegisterNFInstance = originalSendRegisterNFInstance
+		registerNF = originalRegisterNF
 		if keepAliveTimer != nil {
 			keepAliveTimer.Stop()
 		}
 	}()
 
-	called := 0
+	var called atomic.Int32
+	registerAttempts := make(chan struct{}, 2)
+	registerDone := make(chan struct{})
+	var registerDoneOnce sync.Once
 	consumer.SendRegisterNFInstance = func(ctx context.Context, accessAndMobilityConfig []nfConfigApi.AccessAndMobility) (models.NfProfile, string, error) {
 		profile := models.NfProfile{HeartBeatTimer: 60}
-		called++
+		called.Add(1)
+		select {
+		case registerAttempts <- struct{}{}:
+		default:
+		}
 		return profile, "", errors.New("mock error")
+	}
+	registerNF = func(registerCtx context.Context, newAccessAndMobilityConfig []nfConfigApi.AccessAndMobility) {
+		defer registerDoneOnce.Do(func() { close(registerDone) })
+		originalRegisterNF(registerCtx, newAccessAndMobilityConfig)
 	}
 
 	ch := make(chan []nfConfigApi.AccessAndMobility, 1)
-	ctx := t.Context()
-	go StartNfRegistrationService(ctx, ch)
+	ctx, cancel := context.WithCancel(t.Context())
+	serviceDone := make(chan struct{})
+	defer cancel()
+	go func() {
+		defer close(serviceDone)
+		StartNfRegistrationService(ctx, ch)
+	}()
 	ch <- []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -146,12 +214,16 @@ func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T
 		},
 	}
 
-	time.Sleep(2 * retryTime)
+	waitForSignal(t, registerAttempts, retryTime+time.Second, "timed out waiting for first register attempt")
+	waitForSignal(t, registerAttempts, retryTime+time.Second, "timed out waiting for retry register attempt")
+	cancel()
+	waitForSignal(t, registerDone, time.Second, "timed out waiting for register loop to stop")
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
 
-	if called < 2 {
+	if called.Load() < 2 {
 		t.Errorf("expected to retry register to NRF")
 	}
-	t.Logf("Tried %v times", called)
+	t.Logf("Tried %v times", called.Load())
 }
 
 func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCancelled(t *testing.T) {
@@ -163,21 +235,31 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 		}
 	}()
 
+	var registrationsMu sync.Mutex
 	var registrations []struct {
 		ctx    context.Context
 		config []nfConfigApi.AccessAndMobility
 	}
+	registrationStarted := make(chan struct{}, 2)
 	registerNF = func(registerCtx context.Context, newAccessAndMobilityConfig []nfConfigApi.AccessAndMobility) {
+		registrationsMu.Lock()
 		registrations = append(registrations, struct {
 			ctx    context.Context
 			config []nfConfigApi.AccessAndMobility
 		}{registerCtx, newAccessAndMobilityConfig})
+		registrationsMu.Unlock()
+		registrationStarted <- struct{}{}
 		<-registerCtx.Done() // Wait until registration is cancelled
 	}
 
 	ch := make(chan []nfConfigApi.AccessAndMobility, 1)
-	ctx := t.Context()
-	go StartNfRegistrationService(ctx, ch)
+	ctx, cancel := context.WithCancel(t.Context())
+	serviceDone := make(chan struct{})
+	defer cancel()
+	go func() {
+		defer close(serviceDone)
+		StartNfRegistrationService(ctx, ch)
+	}()
 	firstConfig := []nfConfigApi.AccessAndMobility{
 		{
 			PlmnId: *nfConfigApi.NewPlmnId("001", "01"),
@@ -187,10 +269,12 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 	}
 	ch <- firstConfig
 
-	time.Sleep(10 * time.Millisecond)
+	waitForSignal(t, registrationStarted, time.Second, "timed out waiting for first registration")
+	registrationsMu.Lock()
 	if len(registrations) != 1 {
 		t.Errorf("expected one registration to the NRF")
 	}
+	registrationsMu.Unlock()
 
 	secondConfig := []nfConfigApi.AccessAndMobility{
 		{
@@ -200,7 +284,8 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 		},
 	}
 	ch <- secondConfig
-	time.Sleep(10 * time.Millisecond)
+	waitForSignal(t, registrationStarted, time.Second, "timed out waiting for second registration")
+	registrationsMu.Lock()
 	if len(registrations) != 2 {
 		t.Errorf("expected 2 registrations to the NRF")
 	}
@@ -225,6 +310,10 @@ func TestNfRegistrationService_WhenConfigChanged_ThenPreviousRegistrationIsCance
 	if !reflect.DeepEqual(registrations[1].config, secondConfig) {
 		t.Errorf("expected %+v config, received %+v", secondConfig, registrations)
 	}
+	registrationsMu.Unlock()
+
+	cancel()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for NF registration service to stop")
 }
 
 func TestHeartbeatNF_Success(t *testing.T) {

--- a/ngap/ngap_test.go
+++ b/ngap/ngap_test.go
@@ -17,6 +17,27 @@ import (
 	"github.com/omec-project/openapi/models"
 )
 
+func waitForConnData(t *testing.T, conn *ngaputil.TestConn, timeout time.Duration) []byte {
+	t.Helper()
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		data := conn.Snapshot()
+		if len(data) > 0 {
+			return data
+		}
+
+		select {
+		case <-timeoutTimer.C:
+			t.Fatal("timed out waiting for NGAP response")
+		case <-ticker.C:
+		}
+	}
+}
+
 func init() {
 	// Initializing AMF Context from config.
 	testAmfConfig := "../util/testdata/amfcfg.yaml"
@@ -87,23 +108,19 @@ func TestHandleNGSetupRequest(t *testing.T) {
 
 	conn := &ngaputil.TestConn{}
 	for _, test := range testTable {
+		conn.Reset()
 		testNGSetupReq, err := ngaputil.GetNGSetupRequest(test.gnbId, test.bitLength, test.gnbName, test.tac)
 		if err != nil {
 			t.Log("Failed to to create NGSetupRequest")
 			return
 		}
 		ngap.Dispatch(conn, testNGSetupReq)
-		time.Sleep(2 * time.Second)
-		// conn.data holds the NGAP response message
-		if len(conn.Data) == 0 {
-			t.Error("Unexpected message drop")
-			return
-		}
+		response := waitForConnData(t, conn, 2*time.Second)
 
 		// The first byte of the NGAPPDU indicates the type of NGAP Message
-		if conn.Data[0] != test.want {
+		if response[0] != test.want {
 			t.Error("Test case", test.testId, "failed.  Want:",
-				ngaputil.MessageTypeMap[test.want], ",  Got:", ngaputil.MessageTypeMap[conn.Data[0]])
+				ngaputil.MessageTypeMap[test.want], ",  Got:", ngaputil.MessageTypeMap[response[0]])
 		}
 	}
 }

--- a/ngap/util/ngap_util.go
+++ b/ngap/util/ngap_util.go
@@ -7,6 +7,7 @@ package util
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/omec-project/ngap"
@@ -30,6 +31,7 @@ var MessageTypeMap = map[byte]string{
 // Mock Connection struct. Implements the net.Conn interface
 type TestConn struct {
 	Data []byte
+	mu   sync.RWMutex
 }
 
 type TestConnAddr struct{}
@@ -40,8 +42,22 @@ func (tca TestConnAddr) String() (a string)  { return }
 // Write method of the mocked testConn struct will be invoked as a part of the
 // unit test framework
 func (tc *TestConn) Write(b []byte) (n int, err error) {
-	tc.Data = b
-	return
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.Data = append(tc.Data[:0], b...)
+	return len(b), nil
+}
+
+func (tc *TestConn) Snapshot() []byte {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+	return append([]byte(nil), tc.Data...)
+}
+
+func (tc *TestConn) Reset() {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.Data = nil
 }
 
 func (tc *TestConn) Close() (e error) { return }

--- a/polling/nf_configuration_test.go
+++ b/polling/nf_configuration_test.go
@@ -18,11 +18,24 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/omec-project/openapi/nfConfigApi"
 )
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, timeout time.Duration, message string) {
+	t.Helper()
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	select {
+	case <-signal:
+	case <-timeoutTimer.C:
+		t.Fatal(message)
+	}
+}
 
 func makeAccessMobilityConfig(mcc, mnc, sst string, sd string, tacs []string) (nfConfigApi.AccessAndMobility, error) {
 	sstUint64, err := strconv.ParseUint(sst, 10, 8)
@@ -44,9 +57,10 @@ func makeAccessMobilityConfig(mcc, mnc, sst string, sd string, tacs []string) (n
 }
 
 func TestStartPollingService_Success(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
 	originalFetchAccessAndMobilityConfig := fetchAccessAndMobilityConfig
 	defer func() {
+		cancel()
 		fetchAccessAndMobilityConfig = originalFetchAccessAndMobilityConfig
 	}()
 
@@ -63,15 +77,20 @@ func TestStartPollingService_Success(t *testing.T) {
 	}
 	regChan := make(chan []nfConfigApi.AccessAndMobility, 1)
 	updateCtxChan := make(chan []nfConfigApi.AccessAndMobility, 1)
-	go StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
-	time.Sleep(initialPollingInterval)
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	}()
 
 	select {
 	case result := <-updateCtxChan:
 		if !reflect.DeepEqual(result, expectedConfig) {
 			t.Errorf("expected %+v, got %+v", expectedConfig, result)
 		}
-	case <-time.After(100 * time.Millisecond):
+		cancel()
+		waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
+	case <-time.After(initialPollingInterval + time.Second):
 		t.Errorf("timeout waiting for PLMN config")
 	}
 }
@@ -81,28 +100,38 @@ func TestStartPollingService_RetryAfterFailure(t *testing.T) {
 	originalFetchAccessAndMobilityConfig := fetchAccessAndMobilityConfig
 	defer func() { fetchAccessAndMobilityConfig = originalFetchAccessAndMobilityConfig }()
 
-	callCount := 0
+	var callCount atomic.Int32
+	attempts := make(chan struct{}, 2)
 	fetchAccessAndMobilityConfig = func(poller *nfConfigPoller, pollingEndpoint string) ([]nfConfigApi.AccessAndMobility, error) {
-		callCount++
+		callCount.Add(1)
+		select {
+		case attempts <- struct{}{}:
+		default:
+		}
 		return nil, errors.New("mock failure")
 	}
 	regChan := make(chan []nfConfigApi.AccessAndMobility, 1)
 	updateCtxChan := make(chan []nfConfigApi.AccessAndMobility, 1)
-	go StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	}()
 
-	time.Sleep(4 * initialPollingInterval)
+	waitForSignal(t, attempts, initialPollingInterval+time.Second, "timed out waiting for first polling attempt")
+	waitForSignal(t, attempts, 2*initialPollingInterval+time.Second, "timed out waiting for retry polling attempt")
 	cancel()
 	<-ctx.Done()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 
-	if callCount < 2 {
+	if callCount.Load() < 2 {
 		t.Errorf("expected to retry after failure")
 	}
-	t.Logf("Tried %v times", callCount)
+	t.Logf("Tried %v times", callCount.Load())
 }
 
 func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	originalFetcher := fetchAccessAndMobilityConfig
 	defer func() { fetchAccessAndMobilityConfig = originalFetcher }()
 	accessMobility1, err := makeAccessMobilityConfig("222", "02", "1", "1", []string{"1"})
@@ -117,7 +146,11 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 
 	regChan := make(chan []nfConfigApi.AccessAndMobility, 1)
 	updateCtxChan := make(chan []nfConfigApi.AccessAndMobility, 1)
-	go StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	}()
 
 	timeout := time.After(5 * initialPollingInterval)
 	for i := range 1 {
@@ -132,6 +165,7 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 
 	cancel()
 	<-ctx.Done()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 
 	if callCount != 1 {
 		t.Errorf("expected callback to be called once for new config, got %d", callCount)
@@ -140,7 +174,6 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 
 func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	originalFetcher := fetchAccessAndMobilityConfig
 	defer func() { fetchAccessAndMobilityConfig = originalFetcher }()
 	accessMobility1, err := makeAccessMobilityConfig("111", "01", "1", "1", []string{"1"})
@@ -151,10 +184,11 @@ func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create access mobility config: %v", err)
 	}
-	callCount := 0
+	var fetchCount atomic.Int32
+	receivedCount := 0
 
 	fetchAccessAndMobilityConfig = func(poller *nfConfigPoller, endpoint string) ([]nfConfigApi.AccessAndMobility, error) {
-		if callCount == 0 {
+		if fetchCount.Add(1) == 1 {
 			return []nfConfigApi.AccessAndMobility{accessMobility1}, nil
 		}
 		return []nfConfigApi.AccessAndMobility{accessMobility2}, nil
@@ -162,13 +196,17 @@ func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 
 	regChan := make(chan []nfConfigApi.AccessAndMobility, 2)
 	updateCtxChan := make(chan []nfConfigApi.AccessAndMobility, 2)
-	go StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
+	}()
 
 	timeout := time.After(5 * initialPollingInterval)
 	for i := 0; i < 2; i++ {
 		select {
 		case <-updateCtxChan:
-			callCount++
+			receivedCount++
 			// expected update
 		case <-timeout:
 			t.Fatalf("Timed out waiting for config update #%d", i+1)
@@ -177,9 +215,10 @@ func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 
 	cancel()
 	<-ctx.Done()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 
-	if callCount != 2 {
-		t.Errorf("expected callback to be called twice for different configs, got %d", callCount)
+	if receivedCount != 2 {
+		t.Errorf("expected callback to be called twice for different configs, got %d", receivedCount)
 	}
 }
 

--- a/polling/nf_configuration_test.go
+++ b/polling/nf_configuration_test.go
@@ -37,6 +37,12 @@ func waitForSignal(t *testing.T, signal <-chan struct{}, timeout time.Duration, 
 	}
 }
 
+func cleanupPollingService(t *testing.T, cancel context.CancelFunc, serviceDone <-chan struct{}) {
+	t.Helper()
+	cancel()
+	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
+}
+
 func makeAccessMobilityConfig(mcc, mnc, sst string, sd string, tacs []string) (nfConfigApi.AccessAndMobility, error) {
 	sstUint64, err := strconv.ParseUint(sst, 10, 8)
 	if err != nil {
@@ -59,10 +65,9 @@ func makeAccessMobilityConfig(mcc, mnc, sst string, sd string, tacs []string) (n
 func TestStartPollingService_Success(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	originalFetchAccessAndMobilityConfig := fetchAccessAndMobilityConfig
-	defer func() {
-		cancel()
+	t.Cleanup(func() {
 		fetchAccessAndMobilityConfig = originalFetchAccessAndMobilityConfig
-	}()
+	})
 
 	expectedConfig := []nfConfigApi.AccessAndMobility{
 		{
@@ -82,14 +87,15 @@ func TestStartPollingService_Success(t *testing.T) {
 		defer close(serviceDone)
 		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
 	}()
+	t.Cleanup(func() {
+		cleanupPollingService(t, cancel, serviceDone)
+	})
 
 	select {
 	case result := <-updateCtxChan:
 		if !reflect.DeepEqual(result, expectedConfig) {
 			t.Errorf("expected %+v, got %+v", expectedConfig, result)
 		}
-		cancel()
-		waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 	case <-time.After(initialPollingInterval + time.Second):
 		t.Errorf("timeout waiting for PLMN config")
 	}
@@ -98,7 +104,7 @@ func TestStartPollingService_Success(t *testing.T) {
 func TestStartPollingService_RetryAfterFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	originalFetchAccessAndMobilityConfig := fetchAccessAndMobilityConfig
-	defer func() { fetchAccessAndMobilityConfig = originalFetchAccessAndMobilityConfig }()
+	t.Cleanup(func() { fetchAccessAndMobilityConfig = originalFetchAccessAndMobilityConfig })
 
 	var callCount atomic.Int32
 	attempts := make(chan struct{}, 2)
@@ -117,12 +123,12 @@ func TestStartPollingService_RetryAfterFailure(t *testing.T) {
 		defer close(serviceDone)
 		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
 	}()
+	t.Cleanup(func() {
+		cleanupPollingService(t, cancel, serviceDone)
+	})
 
 	waitForSignal(t, attempts, initialPollingInterval+time.Second, "timed out waiting for first polling attempt")
 	waitForSignal(t, attempts, 2*initialPollingInterval+time.Second, "timed out waiting for retry polling attempt")
-	cancel()
-	<-ctx.Done()
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 
 	if callCount.Load() < 2 {
 		t.Errorf("expected to retry after failure")
@@ -133,7 +139,7 @@ func TestStartPollingService_RetryAfterFailure(t *testing.T) {
 func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	originalFetcher := fetchAccessAndMobilityConfig
-	defer func() { fetchAccessAndMobilityConfig = originalFetcher }()
+	t.Cleanup(func() { fetchAccessAndMobilityConfig = originalFetcher })
 	accessMobility1, err := makeAccessMobilityConfig("222", "02", "1", "1", []string{"1"})
 	if err != nil {
 		t.Fatalf("failed to create access mobility config: %v", err)
@@ -151,6 +157,9 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 		defer close(serviceDone)
 		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
 	}()
+	t.Cleanup(func() {
+		cleanupPollingService(t, cancel, serviceDone)
+	})
 
 	timeout := time.After(5 * initialPollingInterval)
 	for i := range 1 {
@@ -163,10 +172,6 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 		}
 	}
 
-	cancel()
-	<-ctx.Done()
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
-
 	if callCount != 1 {
 		t.Errorf("expected callback to be called once for new config, got %d", callCount)
 	}
@@ -175,7 +180,7 @@ func TestStartPollingService_NoUpdateOnIdenticalPlmnConfig(t *testing.T) {
 func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	originalFetcher := fetchAccessAndMobilityConfig
-	defer func() { fetchAccessAndMobilityConfig = originalFetcher }()
+	t.Cleanup(func() { fetchAccessAndMobilityConfig = originalFetcher })
 	accessMobility1, err := makeAccessMobilityConfig("111", "01", "1", "1", []string{"1"})
 	if err != nil {
 		t.Fatalf("failed to create access mobility config: %v", err)
@@ -201,6 +206,9 @@ func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 		defer close(serviceDone)
 		StartPollingService(ctx, "http://dummy", regChan, updateCtxChan)
 	}()
+	t.Cleanup(func() {
+		cleanupPollingService(t, cancel, serviceDone)
+	})
 
 	timeout := time.After(5 * initialPollingInterval)
 	for i := 0; i < 2; i++ {
@@ -212,10 +220,6 @@ func TestStartPollingService_UpdateOnDifferentConfig(t *testing.T) {
 			t.Fatalf("Timed out waiting for config update #%d", i+1)
 		}
 	}
-
-	cancel()
-	<-ctx.Done()
-	waitForSignal(t, serviceDone, time.Second, "timed out waiting for polling service to stop")
 
 	if receivedCount != 2 {
 		t.Errorf("expected callback to be called twice for different configs, got %d", receivedCount)


### PR DESCRIPTION
Once in a while a race condition shows up when running the unit-tests, as shown [here](https://github.com/omec-project/amf/actions/runs/24226506552/job/70728647374). This PR addresses this issue

```
2026-04-10T04:34:03.357Z	INFO	nfregistration/nf_registration.go:47	NF registration service shutting down	{"component": "AMF", "category": "NrfRegistration"}
2026-04-10T04:34:03.357Z	WARN	context/context.go:670	empty TACs for {Mcc:001 Mnc:01} (SNssai: {Sst:3 Sd:<nil>})	{"component": "AMF", "category": "Context"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xf87459]

goroutine 28 [running]:
github.com/omec-project/amf/context.flattenPlmnSnssaiMap(0xc000054b38)
	/home/runner/work/amf/amf/context/context.go:701 +0x3b9
github.com/omec-project/amf/context.ConvertAccessAndMobilityList({0xc00035e6e0, 0x1, 0xc000213c90?})
	/home/runner/work/amf/amf/context/context.go:681 +0x449
github.com/omec-project/amf/consumer.getNfProfile(_, {_, _, _})
	/home/runner/work/amf/amf/consumer/nf_management.go:29 +0xbb
github.com/omec-project/amf/consumer.init.func2({_, _}, {_, _, _})
	/home/runner/work/amf/amf/consumer/nf_management.go:93 +0xc8
github.com/omec-project/amf/nfregistration.init.func1({0x149fa90, 0xc00035e730}, {0xc00035e6e0, 0x1, 0x1})
	/home/runner/work/amf/amf/nfregistration/nf_registration.go:80 +0x288
created by github.com/omec-project/amf/nfregistration.StartNfRegistrationService in goroutine 27
	/home/runner/work/amf/amf/nfregistration/nf_registration.go:64 +0xaa
FAIL	github.com/omec-project/amf/nfregistration	20.322s
```