### PR TITLE
fix: set RatType correctly during registration

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -626,6 +626,18 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	ue.Location = ue.RanUe[anType].Location
 	ue.Tai = ue.RanUe[anType].Tai
 
+	switch anType {
+	case models.AccessType__3_GPP_ACCESS:
+		switch {
+		case ue.Location.NrLocation != nil:
+			ue.RatType = models.RatType_NR
+		case ue.Location.EutraLocation != nil:
+			ue.RatType = models.RatType_EUTRA
+		}
+	case models.AccessType_NON_3_GPP_ACCESS:
+		ue.RatType = models.RatType_WLAN
+	}
+
 	// Check TAI
 	taiList := make([]models.Tai, len(amfSelf.SupportTaiLists))
 	copy(taiList, amfSelf.SupportTaiLists)

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -134,7 +134,9 @@ func CreateUEContextProcedure(ueContextID string, createUeContextRequest models.
 	ue.UdmGroupId = ueContextCreateData.UeContext.UdmGroupId
 	ue.AusfGroupId = ueContextCreateData.UeContext.AusfGroupId
 	// ueContextCreateData.UeContext.HpcfId
-	ue.RatType = ueContextCreateData.UeContext.RestrictedRatList[0] // minItem = -1
+	// RestrictedRatList contains RAT types the UE cannot use, so it must
+	// not be copied into ue.RatType. RatType is set from the access type
+	// during HandleRegistrationRequest (gmm/handler.go).
 	// ueContextCreateData.UeContext.ForbiddenAreaList
 	// ueContextCreateData.UeContext.ServiceAreaRestriction
 	// ueContextCreateData.UeContext.RestrictedCoreNwTypeList


### PR DESCRIPTION
### Problem
During a normal UE registration, ` ue.RatType ` is never set. The only code path that assigns it is ` CreateUEContextProcedure ` in ` producer/ue_context.go ` (inter-AMF relocation), and it does:

` ` ` go
ue.RatType = ueContextCreateData.UeContext.RestrictedRatList[0] // minItem = -1
` ` `

That is wrong on two counts:
- ` RestrictedRatList ` contains RAT types the UE is **not** allowed to use — it's the opposite of what ` RatType ` means.
- The list's minimum item count is -1 (i.e. it can be empty or nil), so indexing ` [0] ` can panic.

As a result, several SBI consumers (` Nsmf_PDUSession ` CreateSMContext, ` Namf_Communication ` UE context management, location reporting, MT notifications) send an empty ` ratType ` field.

### Fix
- Set ` ue.RatType ` in ` HandleRegistrationRequest ` based on access type:
  - 3GPP access + ` NrLocation ` → ` NR `
  - 3GPP access + ` EutraLocation ` → ` EUTRA `
  - Non-3GPP access → ` WLAN `
- Remove the buggy ` RestrictedRatList[0] ` assignment in ` CreateUEContextProcedure ` .

### Test plan
- [x] ` go build ./... ` clean
- [x] ` go vet ./... ` clean
- [x] ` go test ./gmm/... ./producer/... ` pass
- [x] ` make lint ` — 0 issues