### PR TITLE
fix(ngap): add nil guards for three remaining NGAP handlers

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -2103,6 +2103,15 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 		}
 	}
 
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from PDUSessionResourceNotify")
+		return
+	}
+	if aMFUENGAPID == nil {
+		ran.Log.Errorln("AMFUENGAPID IE missing from PDUSessionResourceNotify")
+		return
+	}
+
 	ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
 		ran.Log.Warnf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
@@ -3617,6 +3626,11 @@ func HandleHandoverFailure(ctx ctxt.Context, ran *context.AmfRan, message *ngapT
 		printCriticalityDiagnostics(ran, criticalityDiagnostics)
 	}
 
+	if aMFUENGAPID == nil {
+		ran.Log.Errorln("AMFUENGAPID IE missing from HandoverFailure")
+		return
+	}
+
 	targetUe = context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
 
 	if targetUe == nil {
@@ -4038,6 +4052,11 @@ func HandleUplinkRanStatusTransfer(ran *context.AmfRan, message *ngapType.NGAPPD
 				ran.Log.Errorln("RANStatusTransferTransparentContainer is nil")
 			}
 		}
+	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from UplinkRanStatusTransfer")
+		return
 	}
 
 	ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -2111,6 +2111,10 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 		ran.Log.Errorln("AMFUENGAPID IE missing from PDUSessionResourceNotify")
 		return
 	}
+	if pDUSessionResourceNotifyList == nil {
+		ran.Log.Errorln("PDUSessionResourceNotifyList IE missing from PDUSessionResourceNotify")
+		return
+	}
 
 	ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
@@ -3620,6 +3624,14 @@ func HandleHandoverFailure(ctx ctxt.Context, ran *context.AmfRan, message *ngapT
 	causeValue := ngapType.CauseRadioNetworkPresentHoFailureInTarget5GCNgranNodeOrTargetSystem
 	if cause != nil {
 		causePresent, causeValue = printAndGetCause(ran, cause)
+	} else {
+		ran.Log.Warnln("Cause IE missing from HandoverFailure; using default")
+		cause = &ngapType.Cause{
+			Present: causePresent,
+			RadioNetwork: &ngapType.CauseRadioNetwork{
+				Value: causeValue,
+			},
+		}
 	}
 
 	if criticalityDiagnostics != nil {

--- a/ngap/handler_test.go
+++ b/ngap/handler_test.go
@@ -72,6 +72,72 @@ func TestHandleHandoverNotifyIgnoresMissingIDs(t *testing.T) {
 	HandleHandoverNotify(ctxt.Background(), ran, pdu)
 }
 
+func TestHandlePDUSessionResourceNotifyIgnoresMissingIEs(t *testing.T) {
+	ran := &context.AmfRan{Log: zap.NewNop().Sugar()}
+	pdu := &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentInitiatingMessage,
+		InitiatingMessage: &ngapType.InitiatingMessage{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodePDUSessionResourceNotify},
+			Value: ngapType.InitiatingMessageValue{
+				Present:                  ngapType.InitiatingMessagePresentPDUSessionResourceNotify,
+				PDUSessionResourceNotify: &ngapType.PDUSessionResourceNotify{},
+			},
+		},
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("HandlePDUSessionResourceNotify panicked with missing IEs: %v", recovered)
+		}
+	}()
+
+	HandlePDUSessionResourceNotify(ctxt.Background(), ran, pdu)
+}
+
+func TestHandleHandoverFailureIgnoresMissingIEs(t *testing.T) {
+	ran := &context.AmfRan{Log: zap.NewNop().Sugar()}
+	pdu := &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentUnsuccessfulOutcome,
+		UnsuccessfulOutcome: &ngapType.UnsuccessfulOutcome{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodeHandoverResourceAllocation},
+			Value: ngapType.UnsuccessfulOutcomeValue{
+				Present:         ngapType.UnsuccessfulOutcomePresentHandoverFailure,
+				HandoverFailure: &ngapType.HandoverFailure{},
+			},
+		},
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("HandleHandoverFailure panicked with missing IEs: %v", recovered)
+		}
+	}()
+
+	HandleHandoverFailure(ctxt.Background(), ran, pdu)
+}
+
+func TestHandleUplinkRanStatusTransferIgnoresMissingIEs(t *testing.T) {
+	ran := &context.AmfRan{Log: zap.NewNop().Sugar()}
+	pdu := &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentInitiatingMessage,
+		InitiatingMessage: &ngapType.InitiatingMessage{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodeUplinkRANStatusTransfer},
+			Value: ngapType.InitiatingMessageValue{
+				Present:                 ngapType.InitiatingMessagePresentUplinkRANStatusTransfer,
+				UplinkRANStatusTransfer: &ngapType.UplinkRANStatusTransfer{},
+			},
+		},
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("HandleUplinkRanStatusTransfer panicked with missing IEs: %v", recovered)
+		}
+	}()
+
+	HandleUplinkRanStatusTransfer(ran, pdu)
+}
+
 func TestHandleHandoverRequestAcknowledgeIgnoresMissingAmfUeNgapID(t *testing.T) {
 	ran := &context.AmfRan{Log: zap.NewNop().Sugar()}
 	pdu := &ngapType.NGAPPDU{

--- a/ngap/handler_test.go
+++ b/ngap/handler_test.go
@@ -101,8 +101,8 @@ func TestHandleHandoverFailureIgnoresMissingIEs(t *testing.T) {
 		UnsuccessfulOutcome: &ngapType.UnsuccessfulOutcome{
 			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodeHandoverResourceAllocation},
 			Value: ngapType.UnsuccessfulOutcomeValue{
-				Present:         ngapType.UnsuccessfulOutcomePresentHandoverFailure,
-				HandoverFailure: &ngapType.HandoverFailure{},
+				Present:                    ngapType.UnsuccessfulOutcomePresentHandoverResourceAllocation,
+				HandoverResourceAllocation: &ngapType.HandoverFailure{},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Follow-up to #666. Three handlers still dereference mandatory IE pointers without a post-loop nil guard, so a malformed NGAP message that omits the IE entirely from `ProtocolIEs.List` can crash the AMF.

The in-loop checks only catch "IE present but value nil" — they log and continue instead of returning, leaving the variable nil for the post-loop dereference.

## Handlers fixed

| Handler | IEs guarded | Reason dispatcher doesn't already cover it |
|---|---|---|
| `HandlePDUSessionResourceNotify` | `rANUENGAPID`, `aMFUENGAPID` | Dispatcher only nil-checks `rANUENGAPID`, not `aMFUENGAPID` |
| `HandleHandoverFailure` | `aMFUENGAPID` | Arrives in `UnsuccessfulOutcome`, which `FetchRanUeContext` does not pre-process |
| `HandleUplinkRanStatusTransfer` | `rANUENGAPID` | `FetchRanUeContext` has an empty case for this procedure code |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./ngap/...` — clean
- [x] `go test ./ngap/...` — passes

## Related

- #666 — covered 5 of the 8 handlers originally in scope; this PR finishes the remaining 3
- #661 — covered 3 additional handlers (LocationReportingFailureIndication, RRCInactiveTransitionReport, UplinkUEAssociatedNRPPATransport)