### PR TITLE
feat: derive ue.RatType (incl. NR-NTN orbit class) from NGSetup

### DIFF
--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -55,8 +55,9 @@ type AmfRan struct {
 }
 
 type SupportedTAI struct {
-	Tai        models.Tai
-	SNssaiList []models.Snssai
+	Tai            models.Tai
+	SNssaiList     []models.Snssai
+	RatInformation *ngapType.RATInformation
 }
 
 func NewSupportedTAI() (tai SupportedTAI) {
@@ -66,6 +67,26 @@ func NewSupportedTAI() (tai SupportedTAI) {
 
 func NewSupportedTAIList() []SupportedTAI {
 	return make([]SupportedTAI, 0, maxNumOfTAI*maxNumOfBroadcastPLMNs)
+}
+
+// RatInformationForTAC returns the RATInformation advertised by this RAN
+// for the given TAC, or nil when the RAN's NGSetup did not carry the
+// optional extension for that TAC.
+//
+// RATInformation is a Rel-18 NGAP IE (3GPP TS 38.413) carried as an
+// extension of SupportedTAItem; it classifies the cell's RAT (e.g.
+// NRLEO/NRMEO/NRGEO/NROTHERSAT/NbIoT/Unlicensed). Callers typically use
+// the result to upgrade a generic ue.RatType (NR/EUTRA) into an
+// orbit-specific value.
+func (ran *AmfRan) RatInformationForTAC(tac string) *ngapType.RATInformation {
+	ran.RLockRanState()
+	defer ran.RUnlockRanState()
+	for i := range ran.SupportedTAList {
+		if ran.SupportedTAList[i].Tai.Tac == tac {
+			return ran.SupportedTAList[i].RatInformation
+		}
+	}
+	return nil
 }
 
 func (ran *AmfRan) Remove() {

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -481,6 +481,17 @@ func (ue *AmfUe) CmIdle(anType models.AccessType) bool {
 	return !ue.CmConnect(anType)
 }
 
+// IsNtn reports whether the UE is currently being served over NR
+// Non-Terrestrial access, based on the Rel-18 RatType set during
+// registration (see HandleRegistrationRequest).
+func (ue *AmfUe) IsNtn() bool {
+	switch ue.RatType {
+	case models.RATTYPE_NR_LEO, models.RATTYPE_NR_MEO, models.RATTYPE_NR_GEO, models.RATTYPE_NR_OTHER_SAT:
+		return true
+	}
+	return false
+}
+
 func (ue *AmfUe) Remove() {
 	ue.Mutex.Lock()
 	ranUes := make([]*RanUe, 0, len(ue.RanUe))

--- a/context/ntn_test.go
+++ b/context/ntn_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"testing"
+
+	"github.com/omec-project/ngap/v2/ngapType"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+func TestAmfUeIsNtn(t *testing.T) {
+	tests := []struct {
+		ratType models.RatType
+		want    bool
+	}{
+		{ratType: "", want: false},
+		{ratType: models.RATTYPE_NR, want: false},
+		{ratType: models.RATTYPE_EUTRA, want: false},
+		{ratType: models.RATTYPE_WLAN, want: false},
+		{ratType: models.RATTYPE_NR_LEO, want: true},
+		{ratType: models.RATTYPE_NR_MEO, want: true},
+		{ratType: models.RATTYPE_NR_GEO, want: true},
+		{ratType: models.RATTYPE_NR_OTHER_SAT, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.ratType), func(t *testing.T) {
+			ue := &AmfUe{RatType: tc.ratType}
+			if got := ue.IsNtn(); got != tc.want {
+				t.Errorf("IsNtn() with RatType=%q = %v, want %v", tc.ratType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAmfRanRatInformationForTAC(t *testing.T) {
+	leo := &ngapType.RATInformation{Value: ngapType.RATInformationPresentNRLEO}
+	geo := &ngapType.RATInformation{Value: ngapType.RATInformationPresentNRGEO}
+	ran := &AmfRan{
+		SupportedTAList: []SupportedTAI{
+			{Tai: models.Tai{Tac: "000001"}, RatInformation: leo},
+			{Tai: models.Tai{Tac: "000002"}, RatInformation: nil},
+			{Tai: models.Tai{Tac: "000003"}, RatInformation: geo},
+		},
+	}
+
+	tests := []struct {
+		name string
+		tac  string
+		want *ngapType.RATInformation
+	}{
+		{name: "TAC with NRLEO", tac: "000001", want: leo},
+		{name: "TAC with no extension", tac: "000002", want: nil},
+		{name: "TAC with NRGEO", tac: "000003", want: geo},
+		{name: "unknown TAC", tac: "ffffff", want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ran.RatInformationForTAC(tc.tac)
+			if got != tc.want {
+				t.Errorf("RatInformationForTAC(%q) = %p, want %p", tc.tac, got, tc.want)
+			}
+			if got != nil && tc.want != nil && got.Value != tc.want.Value {
+				t.Errorf("RatInformationForTAC(%q).Value = %v, want %v", tc.tac, got.Value, tc.want.Value)
+			}
+		})
+	}
+}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -674,6 +674,40 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	ue.Location = ue.RanUe[anType].Location
 	ue.Tai = ue.RanUe[anType].Tai
 
+	// Set ue.RatType from the access type. Without this, ue.RatType stays
+	// empty during normal registration and downstream SBI consumers
+	// (Nsmf_PDUSession CreateSMContext, Namf_Communication, location and
+	// MT services) send an empty ratType.
+	switch anType {
+	case models.ACCESSTYPE__3_GPP_ACCESS:
+		switch {
+		case ue.Location.NrLocation != nil:
+			ue.RatType = models.RATTYPE_NR
+		case ue.Location.EutraLocation != nil:
+			ue.RatType = models.RATTYPE_EUTRA
+		}
+	case models.ACCESSTYPE_NON_3_GPP_ACCESS:
+		ue.RatType = models.RATTYPE_WLAN
+	}
+
+	// Rel-18 NR-NTN: if the serving RAN advertised RATInformation for this
+	// TAC at NGSetup, upgrade the generic NR RatType to the orbit-specific
+	// value (NR_LEO/NR_MEO/NR_GEO/NR_OTHER_SAT) per 3GPP TS 29.571.
+	if ue.RatType == models.RATTYPE_NR && ue.RanUe[anType] != nil && ue.RanUe[anType].Ran != nil {
+		if ratInfo := ue.RanUe[anType].Ran.RatInformationForTAC(ue.Tai.Tac); ratInfo != nil {
+			switch ratInfo.Value {
+			case ngapType.RATInformationPresentNRLEO:
+				ue.RatType = models.RATTYPE_NR_LEO
+			case ngapType.RATInformationPresentNRMEO:
+				ue.RatType = models.RATTYPE_NR_MEO
+			case ngapType.RATInformationPresentNRGEO:
+				ue.RatType = models.RATTYPE_NR_GEO
+			case ngapType.RATInformationPresentNROTHERSAT:
+				ue.RatType = models.RATTYPE_NR_OTHER_SAT
+			}
+		}
+	}
+
 	// Check TAI
 	taiList := make([]models.Tai, len(amfSelf.SupportTaiLists))
 	copy(taiList, amfSelf.SupportTaiLists)

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -617,10 +617,22 @@ func HandleNGSetupRequest(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 		for i := 0; i < len(supportedTAList.List); i++ {
 			supportedTAItem := supportedTAList.List[i]
 			tac := hex.EncodeToString(supportedTAItem.TAC.Value)
+			// RATInformation is an optional Rel-18 extension on SupportedTAItem
+			// (3GPP TS 38.413). When present it classifies this TAC's RAT
+			// (e.g. NRLEO/NRMEO/NRGEO/NROTHERSAT) and lets later registration
+			// flows assign an orbit-specific ue.RatType. Copy the value out
+			// so the long-lived RAN context does not retain the decoded PDU.
+			var ratInformation *ngapType.RATInformation
+			if supportedTAItem.IEExtensions != nil {
+				if found := supportedTAItem.IEExtensions.FindRATInformation(); found != nil {
+					ratInformation = &ngapType.RATInformation{Value: found.Value}
+				}
+			}
 			capOfSupportTai := cap(ran.SupportedTAList)
 			for j := 0; j < len(supportedTAItem.BroadcastPLMNList.List); j++ {
 				supportedTAI := context.NewSupportedTAI()
 				supportedTAI.Tai.Tac = tac
+				supportedTAI.RatInformation = ratInformation
 				broadcastPLMNItem := supportedTAItem.BroadcastPLMNList.List[j]
 				plmnId, err := ngapConvert.PlmnIdToModels(broadcastPLMNItem.PLMNIdentity)
 				if err != nil {
@@ -4242,10 +4254,22 @@ func HandleRanConfigurationUpdate(ran *context.AmfRan, message *ngapType.NGAPPDU
 		for i := 0; i < len(supportedTAList.List); i++ {
 			supportedTAItem := supportedTAList.List[i]
 			tac := hex.EncodeToString(supportedTAItem.TAC.Value)
+			// RATInformation is an optional Rel-18 extension on SupportedTAItem
+			// (3GPP TS 38.413). When present it classifies this TAC's RAT
+			// (e.g. NRLEO/NRMEO/NRGEO/NROTHERSAT) and lets later registration
+			// flows assign an orbit-specific ue.RatType. Copy the value out
+			// so the long-lived RAN context does not retain the decoded PDU.
+			var ratInformation *ngapType.RATInformation
+			if supportedTAItem.IEExtensions != nil {
+				if found := supportedTAItem.IEExtensions.FindRATInformation(); found != nil {
+					ratInformation = &ngapType.RATInformation{Value: found.Value}
+				}
+			}
 			capOfSupportTai := cap(ran.SupportedTAList)
 			for j := 0; j < len(supportedTAItem.BroadcastPLMNList.List); j++ {
 				supportedTAI := context.NewSupportedTAI()
 				supportedTAI.Tai.Tac = tac
+				supportedTAI.RatInformation = ratInformation
 				broadcastPLMNItem := supportedTAItem.BroadcastPLMNList.List[j]
 				plmnId, err := ngapConvert.PlmnIdToModels(broadcastPLMNItem.PLMNIdentity)
 				if err != nil {

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -151,7 +151,12 @@ func CreateUEContextProcedure(ueContextID string, createUeContextRequest models.
 	ue.UdmGroupId = ueContextCreateData.UeContext.GetUdmGroupId()
 	ue.AusfGroupId = ueContextCreateData.UeContext.GetAusfGroupId()
 	// ueContextCreateData.UeContext.HpcfId
-	ue.RatType = ueContextCreateData.UeContext.RestrictedRatList[0] // minItem = -1
+	// RestrictedRatList contains RAT types the UE cannot use, so it must
+	// not be copied into ue.RatType (semantically inverted, and indexing
+	// [0] can panic on an empty list — minItem = -1 per spec). RatType is
+	// set from the access type during HandleRegistrationRequest
+	// (gmm/handler.go) and upgraded for NTN cells based on RATInformation
+	// from NGSetup.
 	// ueContextCreateData.UeContext.ForbiddenAreaList
 	// ueContextCreateData.UeContext.ServiceAreaRestriction
 	// ueContextCreateData.UeContext.RestrictedCoreNwTypeList


### PR DESCRIPTION
Following the Rel-18 NGAP uplift ([omec-project/ngap#99](https://github.com/omec-project/ngap/pull/99)), this PR derives ` ue.RatType ` (including NR-NTN orbit class) from the ` RATInformation ` extension on ` SupportedTAItem ` in ` NGSetupRequest ` — the authoritative Rel-18 signal for NR-NTN/LEO/MEO/GEO classification per 3GPP TS 38.413.

### Changes
- **` context/amf_ran.go ` ** — extend ` SupportedTAI ` with ` RatInformation *ngapType.RATInformation ` ; add ` AmfRan.RatInformationForTAC(tac) ` lookup method.
- **` ngap/handler.go ` ** — in ` HandleNGSetupRequest ` and ` HandleRanConfigurationUpdate ` , decode ` SupportedTAItem.IEExtensions.FindRATInformation() ` per TAC and store on each derived ` SupportedTAI ` .
- **` gmm/handler.go ` ** — in ` HandleRegistrationRequest ` , set ` ue.RatType ` from the access type baseline (` NR ` /` EUTRA ` /` WLAN ` ) and upgrade ` NR ` to ` NR_LEO ` /` NR_MEO ` /` NR_GEO ` /` NR_OTHER_SAT ` when the serving RAN advertised orbit class for the UE's TAC.
- **` producer/ue_context.go ` ** — remove the buggy ` ue.RatType = ueContextCreateData.UeContext.RestrictedRatList[0] ` line (semantically inverted, and indexing ` [0] ` can panic on an empty list — ` minItem = -1 ` per spec).
- **` context/amf_ue.go ` ** — add ` AmfUe.IsNtn() ` as a switch over the orbit-specific RatType values.
- **` context/ntn_test.go ` ** *(new)* — 8 cases for ` IsNtn() ` , 4 cases for ` RatInformationForTAC() ` , plus a compile-time enum guard against future ngap regen renumbering.

### Two adjacent fixes folded in
This PR also fixes ` ue.RatType ` correctness during normal registration. Before this change ` ue.RatType ` stayed empty after a normal registration flow (only ever assigned via the now-removed buggy ` RestrictedRatList[0] ` line during inter-AMF relocation), so every downstream SBI consumer (` Nsmf_PDUSession ` ` CreateSMContext ` , ` Namf_Communication ` , location reporting, MT services) sent an empty ` ratType ` .

### Replaces #684
[#684](https://github.com/omec-project/amf/pull/684) took a per-message ` NRNTN-TAI-Information ` presence-check approach with an ` NtnAccessInfo ` flag on ` AmfUe ` . That was a sensible Rel-17 fallback when ` omec-project/ngap ` was still Rel-15-vintage, but the wrong shape for Rel-18: the regen in ngap#99 added a typed ` RATInformation ` enum on ` SupportedTAItem ` , making NGSetup the natural orbit-class source and obsoleting per-message extension scanning. This PR replaces the old approach entirely; no ` NtnAccessInfo ` , no per-message detection, ` IsNtn() ` becomes a RatType switch.

### Test plan
- [x] ` go build ./... ` clean
- [x] ` go vet ./... ` clean
- [x] ` go test ./... ` pass (12 packages, 12 new test cases in ` context/ntn_test.go ` )
- [x] ` make lint ` (golangci-lint via Docker) — 0 issues