### PR TITLE
fix: send UeLocation in CreateSmContext request

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -299,10 +299,10 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 	if ue.RatType != "" {
 		smContextCreateData.SetRatType(ue.RatType)
 	}
-	// TODO: location is used in roaming scenerio
-	// if ue.Location != nil {
-	// 	smContextCreateData.UeLocation = ue.Location
-	// }
+	// Forward the UE location to the SMF at session creation, mirroring the
+	// SmContextUpdateData paths that already do so. ue.Location is populated
+	// during registration (gmm/handler.go) from NGAP UpdateLocation.
+	smContextCreateData.SetUeLocation(ue.Location)
 	smContextCreateData.SetUeTimeZone(ue.TimeZone)
 	smContextCreateData.SetSmContextStatusUri(context.GetIPv4Uri() + "/namf-callback/v1/smContextStatus/" +
 		ue.Guti + "/" + strconv.Itoa(int(smContext.PduSessionID())))


### PR DESCRIPTION
` buildCreateSmContextRequest ` left ` UeLocation ` commented out behind a stale "roaming scenario" TODO, so at PDU session establishment the AMF told the SMF the RAT type and time zone but not the UE's location. The ` SmContextUpdateData ` paths in the same file already forward ` ue.Location ` (e.g. ` SendUpdateSmContextDeactivateUpCnxState ` , ` SendUpdateSmContextXnHandover ` ) — only the create path omitted it.

` ue.Location ` is populated during registration (` gmm/handler.go ` ) from NGAP ` UpdateLocation ` , so the data is already available. Forwarding it lets the SMF/PCF use UE location for location-aware charging, policy, and lawful-intercept reporting at session setup.

Uses the ` SetUeLocation() ` accessor to match the idiom introduced in #715.

### Test plan
- [x] ` go build ./... ` clean
- [x] ` go vet ./... ` clean
- [x] ` go test ./consumer/ ` pass
- [x] ` make lint ` (golangci-lint via Docker) — 0 issues