### PR TITLE
Handle high priority access service request as data

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -2211,6 +2211,13 @@ func HandleServiceRequest(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 				ue.ConfigurationUpdateMessage, &mobilityRestrictionList)
 			ue.ConfigurationUpdateMessage = nil
 		}
+	case nasMessage.ServiceTypeHighPriorityAccess:
+		// High priority access is a valid service type (TS 24.501 9.11.3.50).
+		// The AMF implements no MPS/priority semantics, so handle it as data
+		// rather than rejecting an otherwise-valid Service Request. Some
+		// modems also send service type 5 for ordinary data sessions.
+		ue.GmmLog.Infoln("handling Service Request with high priority access as data service")
+		fallthrough
 	case nasMessage.ServiceTypeData:
 		plmnAccept := context.IsTaiEqual(ue.Tai, ue.RanUe[anType].Tai)
 		if !plmnAccept {

--- a/gmm/handler_test.go
+++ b/gmm/handler_test.go
@@ -292,6 +292,76 @@ func TestHandleServiceRequestSnapshotsN1N2Message(t *testing.T) {
 	}
 }
 
+func TestHandleServiceRequestHighPriorityAccessHandledAsData(t *testing.T) {
+	// Service type 5 (high priority access) must be handled like service type
+	// 1 (data) instead of being rejected by the default case. The UE is set up
+	// with a Tai that differs from its RanUe's Tai, so the data-service path
+	// takes its "tracking area not allowed" branch and returns nil. Only the
+	// data path performs that check, so reaching it (nil, no "not supported"
+	// error) proves service type 5 falls through into the data case. An
+	// emergency Service Request is included as a control: it still hits the
+	// default case and is rejected.
+	newRegisteredUe := func() *context.AmfUe {
+		ue := &context.AmfUe{
+			GmmLog:                   zap.NewNop().Sugar(),
+			NASLog:                   zap.NewNop().Sugar(),
+			RanUe:                    make(map[models.AccessType]*context.RanUe),
+			OnGoing:                  make(map[models.AccessType]*context.OnGoingProcedureWithPrio),
+			State:                    make(map[models.AccessType]*fsm.State),
+			SubscriptionDataValid:    true,
+			SecurityContextAvailable: true,
+			Pei:                      "imei-001010000000001",
+		}
+		ue.State[models.ACCESSTYPE__3_GPP_ACCESS] = fsm.NewState(context.Registered)
+		ue.OnGoing[models.ACCESSTYPE__3_GPP_ACCESS] = &context.OnGoingProcedureWithPrio{Procedure: context.OnGoingProcedureNothing}
+		ue.NgKsi.Ksi = 1
+
+		ranUe := &context.RanUe{
+			AmfUe: ue,
+			Log:   zap.NewNop().Sugar(),
+			Ran:   &context.AmfRan{AnType: models.ACCESSTYPE__3_GPP_ACCESS, Log: zap.NewNop().Sugar()},
+			Tai: models.Tai{
+				PlmnId: models.PlmnId{Mcc: "001", Mnc: "01"},
+				Tac:    "000002",
+			},
+		}
+		ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] = ranUe
+		ue.Tai = models.Tai{
+			PlmnId: models.PlmnId{Mcc: "001", Mnc: "01"},
+			Tac:    "000001",
+		}
+		return ue
+	}
+
+	tests := []struct {
+		name             string
+		serviceType      uint8
+		wantNotSupported bool
+	}{
+		{"data is accepted (baseline)", nasMessage.ServiceTypeData, false},
+		{"high priority access handled as data", nasMessage.ServiceTypeHighPriorityAccess, false},
+		{"emergency is still rejected (control)", nasMessage.ServiceTypeEmergencyServices, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ue := newRegisteredUe()
+			serviceRequest := nasMessage.NewServiceRequest(0)
+			serviceRequest.SetServiceTypeValue(tc.serviceType)
+
+			err := HandleServiceRequest(ctxt.Background(), ue, models.ACCESSTYPE__3_GPP_ACCESS, serviceRequest)
+
+			if tc.wantNotSupported {
+				if err == nil || !strings.Contains(err.Error(), "is not supported") {
+					t.Fatalf("service type %d: expected \"not supported\" error, got %v", tc.serviceType, err)
+				}
+			} else if err != nil {
+				t.Fatalf("service type %d: expected nil error (handled as data), got %v", tc.serviceType, err)
+			}
+		})
+	}
+}
+
 func TestHandleInitialRegistrationSnapshotsRegistrationRequest(t *testing.T) {
 	originalHandleRequestedNssaiForRegistration := handleRequestedNssaiForRegistration
 	originalGetSubscribedNssaiForRegistration := getSubscribedNssaiForRegistration


### PR DESCRIPTION
### What

Handle NAS Service Request service type 5 (high priority access,
TS 24.501 §9.11.3.50) as data instead of rejecting it.

Previously service type 5 fell through to the `default` case in
`HandleServiceRequest` and returned "service type[5] is not supported",
causing the AMF to send a Service Reject.

### Why

High priority access is a valid service type. The AMF implements no
MPS/priority semantics, so there is no priority behaviour to preserve;
handling it the same as service type 1 (data) is correct and avoids
rejecting otherwise-valid requests. This also accommodates modems that
send service type 5 for ordinary data sessions (e.g. Xiaomi M11 Lite 5G /
Qualcomm, some Quectel firmwares), which otherwise cannot recover from idle.

### How

Add a `case nasMessage.ServiceTypeHighPriorityAccess` that logs and falls
through into the existing `ServiceTypeData` handling. No config, no
behavioural change for any other service type.

### Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `gofmt` clean, `golangci-lint` clean on the change
