### PR TITLE
fix(ngap): add nil guards for missing mandatory NGAP-ID IEs in handlers

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -802,7 +802,7 @@ func HandleUplinkNasTransport(ctx ctxt.Context, ran *context.AmfRan, message *ng
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return
@@ -1051,7 +1051,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 		return
 	}
 
-	ranUe := context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
+	ranUe := findRanUeByAmfNgapID(ran, aMFUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No RanUe Context[AmfUeNgapID: %d]", aMFUENGAPID.Value)
 		cause := ngapType.Cause{
@@ -1342,7 +1342,7 @@ func HandlePDUSessionResourceReleaseResponse(ctx ctxt.Context, ran *context.AmfR
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return
@@ -2526,7 +2526,7 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return
@@ -2690,7 +2690,7 @@ func HandleInitialContextSetupFailure(ctx ctxt.Context, ran *context.AmfRan, mes
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return
@@ -4038,7 +4038,7 @@ func HandleHandoverCancel(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 		return
 	}
 
-	sourceUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	sourceUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if sourceUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		cause := ngapType.Cause{
@@ -4237,7 +4237,7 @@ func HandleNasNonDeliveryIndication(ctx ctxt.Context, ran *context.AmfRan, messa
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return
@@ -4799,7 +4799,7 @@ func HandleUERadioCapabilityInfoIndication(ran *context.AmfRan, message *ngapTyp
 		return
 	}
 
-	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByRanNgapID(ran, rANUENGAPID)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
 		return

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -797,6 +797,10 @@ func HandleUplinkNasTransport(ctx ctxt.Context, ran *context.AmfRan, message *ng
 		ran.Log.Errorln("AMFUENGAPID IE missing from UplinkNasTransport")
 		return
 	}
+	if nASPDU == nil {
+		ran.Log.Errorln("NASPDU IE missing from UplinkNasTransport")
+		return
+	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
@@ -1656,6 +1660,10 @@ func HandleInitialUEMessage(ctx ctxt.Context, ran *context.AmfRan, message *ngap
 
 	if rANUENGAPID == nil {
 		ran.Log.Errorln("RANUENGAPID IE missing from InitialUEMessage")
+		return
+	}
+	if nASPDU == nil {
+		ran.Log.Errorln("NASPDU IE missing from InitialUEMessage")
 		return
 	}
 
@@ -4222,6 +4230,10 @@ func HandleNasNonDeliveryIndication(ctx ctxt.Context, ran *context.AmfRan, messa
 
 	if rANUENGAPID == nil {
 		ran.Log.Errorln("RANUENGAPID IE missing from NASNonDeliveryIndication")
+		return
+	}
+	if nASPDU == nil {
+		ran.Log.Errorln("NASPDU IE missing from NASNonDeliveryIndication")
 		return
 	}
 

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -789,6 +789,11 @@ func HandleUplinkNasTransport(ctx ctxt.Context, ran *context.AmfRan, message *ng
 		}
 	}
 
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from UplinkNasTransport")
+		return
+	}
+
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
@@ -1031,6 +1036,11 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 			criticalityDiagnostics = ie.Value.CriticalityDiagnostics
 			ran.Log.Debugln("decode IE CriticalityDiagnostics")
 		}
+	}
+
+	if aMFUENGAPID == nil {
+		ran.Log.Errorln("AMFUENGAPID IE missing from UEContextReleaseComplete")
+		return
 	}
 
 	ranUe := context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
@@ -1317,6 +1327,11 @@ func HandlePDUSessionResourceReleaseResponse(ctx ctxt.Context, ran *context.AmfR
 			criticalityDiagnostics = ie.Value.CriticalityDiagnostics
 			ran.Log.Debugln("decode IE CriticalityDiagnostics")
 		}
+	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from PDUSessionResourceReleaseResponse")
+		return
 	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
@@ -1632,6 +1647,12 @@ func HandleInitialUEMessage(ctx ctxt.Context, ran *context.AmfRan, message *ngap
 		criticalityDiagnostics := buildCriticalityDiagnostics(&procedureCode, &triggeringMessage, &procedureCriticality,
 			&iesCriticalityDiagnostics)
 		ngap_message.SendErrorIndication(ran, nil, nil, nil, &criticalityDiagnostics)
+		return
+	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from InitialUEMessage")
+		return
 	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
@@ -2488,6 +2509,11 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 		}
 	}
 
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from InitialContextSetupResponse")
+		return
+	}
+
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
@@ -2646,6 +2672,12 @@ func HandleInitialContextSetupFailure(ctx ctxt.Context, ran *context.AmfRan, mes
 	if criticalityDiagnostics != nil {
 		printCriticalityDiagnostics(ran, criticalityDiagnostics)
 	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from InitialContextSetupFailure")
+		return
+	}
+
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
@@ -2744,12 +2776,15 @@ func HandleUEContextReleaseRequest(ctx ctxt.Context, ran *context.AmfRan, messag
 		}
 	}
 
-	ranUe := context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
-	if ranUe == nil {
+	var ranUe *context.RanUe
+	if aMFUENGAPID != nil {
+		ranUe = context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
+	}
+	if ranUe == nil && rANUENGAPID != nil {
 		ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	}
 	if ranUe == nil {
-		ran.Log.Errorf("No RanUe Context[AmfUeNgapID: %d]", aMFUENGAPID.Value)
+		ran.Log.Errorln("No RanUe Context for UEContextReleaseRequest")
 		cause = &ngapType.Cause{
 			Present: ngapType.CausePresentRadioNetwork,
 			RadioNetwork: &ngapType.CauseRadioNetwork{
@@ -3973,6 +4008,11 @@ func HandleHandoverCancel(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 		}
 	}
 
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from HandoverCancel")
+		return
+	}
+
 	sourceUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if sourceUe == nil {
 		ran.Log.Errorf("No UE Context[RanUeNgapID: %d]", rANUENGAPID.Value)
@@ -4161,6 +4201,11 @@ func HandleNasNonDeliveryIndication(ctx ctxt.Context, ran *context.AmfRan, messa
 				return
 			}
 		}
+	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from NASNonDeliveryIndication")
+		return
 	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
@@ -4718,6 +4763,11 @@ func HandleUERadioCapabilityInfoIndication(ran *context.AmfRan, message *ngapTyp
 				return
 			}
 		}
+	}
+
+	if rANUENGAPID == nil {
+		ran.Log.Errorln("RANUENGAPID IE missing from UERadioCapabilityInfoIndication")
+		return
 	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -793,6 +793,10 @@ func HandleUplinkNasTransport(ctx ctxt.Context, ran *context.AmfRan, message *ng
 		ran.Log.Errorln("RANUENGAPID IE missing from UplinkNasTransport")
 		return
 	}
+	if aMFUENGAPID == nil {
+		ran.Log.Errorln("AMFUENGAPID IE missing from UplinkNasTransport")
+		return
+	}
 
 	ranUe := ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	if ranUe == nil {
@@ -2784,7 +2788,16 @@ func HandleUEContextReleaseRequest(ctx ctxt.Context, ran *context.AmfRan, messag
 		ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
 	}
 	if ranUe == nil {
-		ran.Log.Errorln("No RanUe Context for UEContextReleaseRequest")
+		switch {
+		case aMFUENGAPID != nil && rANUENGAPID != nil:
+			ran.Log.Errorf("No RanUe Context[AmfUeNgapID: %d, RanUeNgapID: %d]", aMFUENGAPID.Value, rANUENGAPID.Value)
+		case aMFUENGAPID != nil:
+			ran.Log.Errorf("No RanUe Context[AmfUeNgapID: %d]", aMFUENGAPID.Value)
+		case rANUENGAPID != nil:
+			ran.Log.Errorf("No RanUe Context[RanUeNgapID: %d]", rANUENGAPID.Value)
+		default:
+			ran.Log.Errorln("No RanUe Context for UEContextReleaseRequest")
+		}
 		cause = &ngapType.Cause{
 			Present: ngapType.CausePresentRadioNetwork,
 			RadioNetwork: &ngapType.CauseRadioNetwork{
@@ -4010,6 +4023,10 @@ func HandleHandoverCancel(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 
 	if rANUENGAPID == nil {
 		ran.Log.Errorln("RANUENGAPID IE missing from HandoverCancel")
+		return
+	}
+	if aMFUENGAPID == nil {
+		ran.Log.Errorln("AMFUENGAPID IE missing from HandoverCancel")
 		return
 	}
 

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -2788,12 +2788,9 @@ func HandleUEContextReleaseRequest(ctx ctxt.Context, ran *context.AmfRan, messag
 		}
 	}
 
-	var ranUe *context.RanUe
-	if aMFUENGAPID != nil {
-		ranUe = context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
-	}
-	if ranUe == nil && rANUENGAPID != nil {
-		ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+	ranUe := findRanUeByAmfNgapID(ran, aMFUENGAPID)
+	if ranUe == nil {
+		ranUe = findRanUeByRanNgapID(ran, rANUENGAPID)
 	}
 	if ranUe == nil {
 		switch {


### PR DESCRIPTION
## Description

Several NGAP handlers dereference a mandatory NGAP-ID IE's `.Value` right after the IE-decoding loop. The in-loop checks only catch the "IE present but value is nil" case — an IE that is **entirely absent** from the `ProtocolIEs` list leaves the pointer `nil`, so a malformed/non-conformant peer can panic the AMF by omitting it.

The panic occurs in **two** places per handler: the lookup `RanUeFind…(id.Value)`, **and** the `No UE Context[…: %d]` error log immediately after it (which re-derefs the same ID and is reached precisely when the lookup returns nil).

This adds a post-loop `if <id> == nil { return }` guard before the first dereference in each affected handler.

> Note: simply swapping the lookup for the `findRanUeBy{Ran,Amf}NgapID` helper (as done in #732 for `FetchRanUeContext`) is **not** sufficient for the handlers — the helper returns `nil`, but the subsequent `No UE Context` log still derefs the ID and panics. The guard is needed because it returns *before* both the lookup and the log. (`FetchRanUeContext` is different: it returns the possibly-nil `ranUe` without logging the ID, so the helper is correct there.)

## Handlers guarded (10)

| Handler | ID |
|---|---|
| `HandleInitialUEMessage` (also `return` after the criticality-diagnostics `ErrorIndication`) | RANUENGAPID |
| `HandleInitialContextSetupResponse` | RANUENGAPID |
| `HandleInitialContextSetupFailure` | RANUENGAPID |
| `HandleUEContextReleaseRequest` (nil-safe dual AMFUENGAPID/RANUENGAPID lookup + drop nil-deref from its log) | both |
| `HandleUplinkNasTransport` | RANUENGAPID |
| `HandleUEContextReleaseComplete` | AMFUENGAPID |
| `HandlePDUSessionResourceReleaseResponse` | RANUENGAPID |
| `HandleHandoverCancel` | RANUENGAPID |
| `HandleNasNonDeliveryIndication` | RANUENGAPID |
| `HandleUERadioCapabilityInfoIndication` | RANUENGAPID |

The remaining handlers already guard their mandatory IDs (post-loop `== nil` guard, inline `if id != nil` wrapper, or the criticality-diagnostics `if len > 0 { return }` pattern), so they're left unchanged.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `golangci-lint run --new-from-rev=main` → `0 issues.`
- `gofmt` clean
