### PR TITLE
fix(ngap): route remaining FetchRanUeContext lookups through nil-safe helper

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -247,7 +247,7 @@ func FetchRanUeContext(ran *context.AmfRan, message *ngapType.NGAPPDU) (*context
 					aMFUENGAPID = ie.Value.AMFUENGAPID
 				}
 			}
-			ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+			ranUe = findRanUeByRanNgapID(ran, rANUENGAPID)
 		case ngapType.ProcedureCodeHandoverPreparation:
 			ngapMsg := initiatingMessage.Value.HandoverPreparation
 			for i := 0; i < len(ngapMsg.ProtocolIEs.List); i++ {
@@ -264,7 +264,7 @@ func FetchRanUeContext(ran *context.AmfRan, message *ngapType.NGAPPDU) (*context
 					aMFUENGAPID = ie.Value.AMFUENGAPID
 				}
 			}
-			ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+			ranUe = findRanUeByRanNgapID(ran, rANUENGAPID)
 		case ngapType.ProcedureCodeRANConfigurationUpdate:
 		case ngapType.ProcedureCodeRRCInactiveTransitionReport:
 		case ngapType.ProcedureCodePDUSessionResourceNotify:
@@ -438,7 +438,7 @@ func FetchRanUeContext(ran *context.AmfRan, message *ngapType.NGAPPDU) (*context
 					aMFUENGAPID = ie.Value.AMFUENGAPID
 				}
 			}
-			ranUe = ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)
+			ranUe = findRanUeByRanNgapID(ran, rANUENGAPID)
 
 		case ngapType.ProcedureCodeHandoverResourceAllocation:
 			ngapMsg := successfulOutcome.Value.HandoverResourceAllocation


### PR DESCRIPTION
## Description

#666 introduced the nil-safe helper `findRanUeByRanNgapID()` — it returns `nil` when the `RANUENGAPID` IE pointer is `nil` instead of dereferencing `.Value` — and converted most procedure-code cases in `FetchRanUeContext` to use it. Three cases were missed and still call `ran.RanUeFindByRanUeNgapID(rANUENGAPID.Value)` directly:

- `HandoverNotification`
- `HandoverPreparation`
- `PDUSessionResourceModify` (Response)

In each, the in-loop check only catches a `RANUENGAPID` IE that is **present with a nil value**. If the IE is **entirely absent** from the message, `rANUENGAPID` stays `nil` and the subsequent `.Value` dereference panics the AMF — the same malformed-input crash class #666 set out to close.

This routes those three lookups through `findRanUeByRanNgapID()` like the rest of the function, making `FetchRanUeContext` uniformly nil-safe.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `golangci-lint run --new-from-rev=main` → `0 issues.`
- `gofmt` clean
