### PR TITLE
fix(amf): synchronize AmfUe identity fields to fix a data race

### DIFF
--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -84,9 +84,9 @@ func SDMGetAmData(ctx context.Context, ue *amf_context.AmfUe) (problemDetails *m
 	if localErr == nil {
 		ue.AccessAndMobilitySubscriptionData = data
 		if len(data.Gpsis) > 0 {
-			ue.Gpsi = data.Gpsis[0] // TODO: select GPSI
+			ue.SetGpsi(data.Gpsis[0]) // TODO: select GPSI
 		} else {
-			ue.Gpsi = "" // No GPSI associated with the UE, so clearing GPSI to avoid stale values
+			ue.SetGpsi("") // No GPSI associated with the UE, so clearing GPSI to avoid stale values
 		}
 	} else if httpResp != nil {
 		if httpResp.Status != localErr.Error() {

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -506,11 +506,27 @@ func (ue *AmfUe) IdentitySnapshot() UeIdentity {
 // lock. They guard only the identity fields via identityMu and never take
 // ue.Mutex, so they are safe to call from code already holding ue.Mutex.
 
-func (ue *AmfUe) GetSupi() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Supi }
-func (ue *AmfUe) GetPei() string  { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Pei }
-func (ue *AmfUe) GetGpsi() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Gpsi }
-func (ue *AmfUe) GetGuti() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Guti }
-func (ue *AmfUe) GetTmsi() int32  { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Tmsi }
+func (ue *AmfUe) GetSupi() string {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return ue.Supi
+}
+func (ue *AmfUe) GetPei() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Pei }
+func (ue *AmfUe) GetGpsi() string {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return ue.Gpsi
+}
+func (ue *AmfUe) GetGuti() string {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return ue.Guti
+}
+func (ue *AmfUe) GetTmsi() int32 {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return ue.Tmsi
+}
 
 func (ue *AmfUe) GetRegistrationType5GS() uint8 {
 	ue.identityMu.RLock()
@@ -897,7 +913,7 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) {
 // this is clearing the transient data of registration request, this is called entrypoint of Deregistration and Registration state
 func (ue *AmfUe) ClearRegistrationRequestData(accessType models.AccessType) {
 	ue.RegistrationRequest = nil
-	ue.RegistrationType5GS = 0
+	ue.SetRegistrationType5GS(0)
 	ue.IdentityTypeUsedForRegistration = 0
 	ue.AuthFailureCauseSynchFailureTimes = 0
 	ue.ServingAmfChanged = false
@@ -941,12 +957,12 @@ func (ue *AmfUe) RemoveAmPolicyAssociation() {
 
 func (ue *AmfUe) CopyDataFromUeContextModel(ueContext models.UeContext) {
 	if ueContext.GetSupi() != "" {
-		ue.Supi = ueContext.GetSupi()
+		ue.SetSupi(ueContext.GetSupi())
 		ue.UnauthenticatedSupi = ueContext.GetSupiUnauthInd()
 	}
 
 	if ueContext.GetPei() != "" {
-		ue.Pei = ueContext.GetPei()
+		ue.SetPei(ueContext.GetPei())
 	}
 
 	if ueContext.GetUdmGroupId() != "" {
@@ -1198,10 +1214,10 @@ func (ueContext *AmfUe) PublishUeCtxtInfo() {
 	kafkaSmCtxt := mi.CoreSubscriber{}
 
 	// Populate kafka sm ctxt struct
-	kafkaSmCtxt.Imsi = ueContext.Supi
+	kafkaSmCtxt.Imsi = ueContext.GetSupi()
 	kafkaSmCtxt.AmfId = ueContext.ServingAMF.NfId
-	kafkaSmCtxt.Guti = ueContext.Guti
-	kafkaSmCtxt.Tmsi = ueContext.Tmsi
+	kafkaSmCtxt.Guti = ueContext.GetGuti()
+	kafkaSmCtxt.Tmsi = ueContext.GetTmsi()
 	kafkaSmCtxt.AmfIp = ueContext.AmfInstanceIp
 	if ranUe := ueContext.GetRanUe(models.ACCESSTYPE__3_GPP_ACCESS); ranUe != nil {
 		kafkaSmCtxt.AmfNgapId = ranUe.AmfUeNgapId

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -511,17 +511,21 @@ func (ue *AmfUe) GetSupi() string {
 	defer ue.identityMu.RUnlock()
 	return ue.Supi
 }
+
 func (ue *AmfUe) GetPei() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Pei }
+
 func (ue *AmfUe) GetGpsi() string {
 	ue.identityMu.RLock()
 	defer ue.identityMu.RUnlock()
 	return ue.Gpsi
 }
+
 func (ue *AmfUe) GetGuti() string {
 	ue.identityMu.RLock()
 	defer ue.identityMu.RUnlock()
 	return ue.Guti
 }
+
 func (ue *AmfUe) GetTmsi() int32 {
 	ue.identityMu.RLock()
 	defer ue.identityMu.RUnlock()

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -70,6 +70,13 @@ const (
 type AmfUe struct {
 	// Mutex sync.Mutex `json:"mutex,omitempty" yaml:"mutex" bson:"mutex,omitempty"`
 	Mutex sync.Mutex `json:"-"`
+	// identityMu guards the UE identity fields (Supi/Pei/Gpsi/Tmsi/Guti and
+	// RegistrationType5GS) so they can be read safely from goroutines other than
+	// the one running the UE's NAS procedure (e.g. SBI handlers, logging). Use the
+	// Get*/Set* accessors below; do not touch those fields directly across
+	// goroutines. It is deliberately separate from Mutex (which guards RanUe/CM
+	// state) so an accessor can never self-deadlock against a Mutex holder.
+	identityMu sync.RWMutex `json:"-"`
 	/* the AMF which serving this AmfUe now */
 	ServingAMF *AMFContext `json:"servingAMF,omitempty"` // never nil
 
@@ -465,6 +472,62 @@ func (ue *AmfUe) init() {
 	ue.AmfInstanceName = os.Getenv("HOSTNAME")
 	ue.AmfInstanceIp = os.Getenv("POD_IP")
 	// ue.TransientInfo = make(chan AmfUeTransientInfo, 10)
+}
+
+// UeIdentity is a consistent snapshot of a UE's identity fields, taken under
+// identityMu. Consumers running on a goroutine other than the UE's NAS procedure
+// (SBI handlers, logging, the LI start-of-interception scan, …) must read the
+// identity via IdentitySnapshot or the Get* accessors rather than touching the
+// fields directly, which races the NAS writers (Set* accessors).
+type UeIdentity struct {
+	Supi                string
+	Pei                 string
+	Gpsi                string
+	Guti                string
+	Tmsi                int32
+	RegistrationType5GS uint8
+}
+
+// IdentitySnapshot returns a consistent copy of ue's identity fields.
+func (ue *AmfUe) IdentitySnapshot() UeIdentity {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return UeIdentity{
+		Supi:                ue.Supi,
+		Pei:                 ue.Pei,
+		Gpsi:                ue.Gpsi,
+		Guti:                ue.Guti,
+		Tmsi:                ue.Tmsi,
+		RegistrationType5GS: ue.RegistrationType5GS,
+	}
+}
+
+// Identity-field accessors. Reads take a shared lock; writes take an exclusive
+// lock. They guard only the identity fields via identityMu and never take
+// ue.Mutex, so they are safe to call from code already holding ue.Mutex.
+
+func (ue *AmfUe) GetSupi() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Supi }
+func (ue *AmfUe) GetPei() string  { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Pei }
+func (ue *AmfUe) GetGpsi() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Gpsi }
+func (ue *AmfUe) GetGuti() string { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Guti }
+func (ue *AmfUe) GetTmsi() int32  { ue.identityMu.RLock(); defer ue.identityMu.RUnlock(); return ue.Tmsi }
+
+func (ue *AmfUe) GetRegistrationType5GS() uint8 {
+	ue.identityMu.RLock()
+	defer ue.identityMu.RUnlock()
+	return ue.RegistrationType5GS
+}
+
+func (ue *AmfUe) SetSupi(v string) { ue.identityMu.Lock(); ue.Supi = v; ue.identityMu.Unlock() }
+func (ue *AmfUe) SetPei(v string)  { ue.identityMu.Lock(); ue.Pei = v; ue.identityMu.Unlock() }
+func (ue *AmfUe) SetGpsi(v string) { ue.identityMu.Lock(); ue.Gpsi = v; ue.identityMu.Unlock() }
+func (ue *AmfUe) SetGuti(v string) { ue.identityMu.Lock(); ue.Guti = v; ue.identityMu.Unlock() }
+func (ue *AmfUe) SetTmsi(v int32)  { ue.identityMu.Lock(); ue.Tmsi = v; ue.identityMu.Unlock() }
+
+func (ue *AmfUe) SetRegistrationType5GS(v uint8) {
+	ue.identityMu.Lock()
+	ue.RegistrationType5GS = v
+	ue.identityMu.Unlock()
 }
 
 func (ue *AmfUe) CmConnect(anType models.AccessType) bool {

--- a/context/amf_ue_identity_test.go
+++ b/context/amf_ue_identity_test.go
@@ -31,7 +31,7 @@ func TestAmfUeIdentityConcurrentAccess(t *testing.T) {
 	// registration / GUTI reallocation.
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			ue.SetSupi(fmt.Sprintf("imsi-%015d", i))
 			ue.SetPei(fmt.Sprintf("imeisv-%016d", i))
 			ue.SetGpsi(fmt.Sprintf("msisdn-%d", i))
@@ -44,7 +44,7 @@ func TestAmfUeIdentityConcurrentAccess(t *testing.T) {
 	// Reader: models a consumer on another goroutine reading the UE's identity.
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			id := ue.IdentitySnapshot()
 			// Touch every field so the race detector observes the reads.
 			_ = id.Supi + id.Pei + id.Gpsi + id.Guti

--- a/context/amf_ue_identity_test.go
+++ b/context/amf_ue_identity_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestAmfUeIdentityConcurrentAccess exercises the AmfUe identity fields from two
+// goroutines at once — one writing them the way a NAS procedure does, one reading
+// a consistent snapshot the way an off-NAS consumer does (an SBI handler, logging,
+// or the LI start-of-interception scan). Run under `-race` it must pass.
+//
+// This is the regression test for the AmfUe identity data race: before the Get*/
+// Set*/IdentitySnapshot accessors, both sides touched the fields directly (e.g.
+// `ue.Supi = …` on the NAS goroutine and `_ = ue.Supi` on another), which the race
+// detector flags — and a torn read of a string field is a genuine memory-safety
+// hazard, not just stale data. Replacing the accessor calls below with direct
+// field access reproduces the failure.
+func TestAmfUeIdentityConcurrentAccess(t *testing.T) {
+	ue := &AmfUe{}
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: models the NAS procedure assigning identity fields during
+	// registration / GUTI reallocation.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			ue.SetSupi(fmt.Sprintf("imsi-%015d", i))
+			ue.SetPei(fmt.Sprintf("imeisv-%016d", i))
+			ue.SetGpsi(fmt.Sprintf("msisdn-%d", i))
+			ue.SetGuti(fmt.Sprintf("guti-%d", i))
+			ue.SetTmsi(int32(i))
+			ue.SetRegistrationType5GS(uint8(i % 4))
+		}
+	}()
+
+	// Reader: models a consumer on another goroutine reading the UE's identity.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			id := ue.IdentitySnapshot()
+			// Touch every field so the race detector observes the reads.
+			_ = id.Supi + id.Pei + id.Gpsi + id.Guti
+			_ = id.Tmsi
+			_ = id.RegistrationType5GS
+			// The individual getters must be safe too.
+			_ = ue.GetSupi()
+			_ = ue.GetTmsi()
+			_ = ue.GetRegistrationType5GS()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/context/amf_ue_identity_test.go
+++ b/context/amf_ue_identity_test.go
@@ -31,7 +31,7 @@ func TestAmfUeIdentityConcurrentAccess(t *testing.T) {
 	// registration / GUTI reallocation.
 	go func() {
 		defer wg.Done()
-		for i := range iterations {
+		for i := 0; i < iterations; i++ {
 			ue.SetSupi(fmt.Sprintf("imsi-%015d", i))
 			ue.SetPei(fmt.Sprintf("imeisv-%016d", i))
 			ue.SetGpsi(fmt.Sprintf("msisdn-%d", i))
@@ -44,7 +44,7 @@ func TestAmfUeIdentityConcurrentAccess(t *testing.T) {
 	// Reader: models a consumer on another goroutine reading the UE's identity.
 	go func() {
 		defer wg.Done()
-		for range iterations {
+		for i := 0; i < iterations; i++ {
 			id := ue.IdentitySnapshot()
 			// Touch every field so the race detector observes the reads.
 			_ = id.Supi + id.Pei + id.Gpsi + id.Guti

--- a/context/context.go
+++ b/context/context.go
@@ -153,28 +153,31 @@ func (context *AMFContext) AllocateAmfUeNgapID() (int64, error) {
 
 func (context *AMFContext) AllocateGutiToUe(ue *AmfUe) {
 	servedGuami := context.ServedGuamiList[0]
-	ue.SetTmsi(context.TmsiAllocate())
+	tmsi := context.TmsiAllocate()
+	ue.SetTmsi(tmsi)
 
 	plmnID := servedGuami.PlmnId.Mcc + servedGuami.PlmnId.Mnc
-	tmsiStr := fmt.Sprintf("%08x", ue.Tmsi)
+	tmsiStr := fmt.Sprintf("%08x", tmsi)
 	ue.SetGuti(plmnID + servedGuami.AmfId + tmsiStr)
 }
 
 func (context *AMFContext) ReAllocateGutiToUe(ue *AmfUe) {
 	var err error
 	servedGuami := context.ServedGuamiList[0]
+	oldTmsi := ue.GetTmsi()
 	if context.EnableDbStore {
-		err = context.Drsm.ReleaseInt32ID(ue.Tmsi)
+		err = context.Drsm.ReleaseInt32ID(oldTmsi)
 	} else {
-		tmsiGenerator.FreeID(int64(ue.Tmsi))
+		tmsiGenerator.FreeID(int64(oldTmsi))
 	}
 	if err != nil {
 		logger.ContextLog.Errorf("Error releasing tmsi: %v", err)
 	}
-	ue.SetTmsi(context.TmsiAllocate())
+	tmsi := context.TmsiAllocate()
+	ue.SetTmsi(tmsi)
 
 	plmnID := servedGuami.PlmnId.Mcc + servedGuami.PlmnId.Mnc
-	tmsiStr := fmt.Sprintf("%08x", ue.Tmsi)
+	tmsiStr := fmt.Sprintf("%08x", tmsi)
 	ue.SetGuti(plmnID + servedGuami.AmfId + tmsiStr)
 }
 
@@ -277,7 +280,7 @@ func (context *AMFContext) AddAmfUeToUePool(ue *AmfUe, supi string) {
 		logger.ContextLog.Errorf("Supi is nil")
 	}
 	ue.SetSupi(supi)
-	context.UePool.Store(ue.Supi, ue)
+	context.UePool.Store(supi, ue)
 }
 
 func (context *AMFContext) NewAmfUe(supi string) *AmfUe {
@@ -317,7 +320,7 @@ func (context *AMFContext) AmfUeFindBySupi(supi string) (ue *AmfUe, ok bool) {
 		ue, ok = DbFetchUeBySupi(supi)
 		if ue != nil && ok {
 			logger.ContextLog.Infoln("Ue with supi found in DB : ", supi)
-			context.UePool.Store(ue.Supi, ue)
+			context.UePool.Store(supi, ue)
 		} else {
 			logger.ContextLog.Infoln("Ue with Supi not found locally and in DB: ", supi)
 		}
@@ -501,7 +504,7 @@ func (context *AMFContext) AmfUeFindByGuti(guti string) (ue *AmfUe, ok bool) {
 		ue, ok = DbFetchUeByGuti(guti)
 		if ue != nil && ok {
 			logger.ContextLog.Infoln("Ue with Guti found in DB : ", guti)
-			context.UePool.Store(ue.Supi, ue)
+			context.UePool.Store(ue.GetSupi(), ue)
 		} else {
 			logger.ContextLog.Infoln("Ue with Guti not found locally and in DB: ", guti)
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -153,11 +153,11 @@ func (context *AMFContext) AllocateAmfUeNgapID() (int64, error) {
 
 func (context *AMFContext) AllocateGutiToUe(ue *AmfUe) {
 	servedGuami := context.ServedGuamiList[0]
-	ue.Tmsi = context.TmsiAllocate()
+	ue.SetTmsi(context.TmsiAllocate())
 
 	plmnID := servedGuami.PlmnId.Mcc + servedGuami.PlmnId.Mnc
 	tmsiStr := fmt.Sprintf("%08x", ue.Tmsi)
-	ue.Guti = plmnID + servedGuami.AmfId + tmsiStr
+	ue.SetGuti(plmnID + servedGuami.AmfId + tmsiStr)
 }
 
 func (context *AMFContext) ReAllocateGutiToUe(ue *AmfUe) {
@@ -171,11 +171,11 @@ func (context *AMFContext) ReAllocateGutiToUe(ue *AmfUe) {
 	if err != nil {
 		logger.ContextLog.Errorf("Error releasing tmsi: %v", err)
 	}
-	ue.Tmsi = context.TmsiAllocate()
+	ue.SetTmsi(context.TmsiAllocate())
 
 	plmnID := servedGuami.PlmnId.Mcc + servedGuami.PlmnId.Mnc
 	tmsiStr := fmt.Sprintf("%08x", ue.Tmsi)
-	ue.Guti = plmnID + servedGuami.AmfId + tmsiStr
+	ue.SetGuti(plmnID + servedGuami.AmfId + tmsiStr)
 }
 
 func (context *AMFContext) AllocateRegistrationArea(ue *AmfUe, anType models.AccessType) {
@@ -276,7 +276,7 @@ func (context *AMFContext) AddAmfUeToUePool(ue *AmfUe, supi string) {
 	if len(supi) == 0 {
 		logger.ContextLog.Errorf("Supi is nil")
 	}
-	ue.Supi = supi
+	ue.SetSupi(supi)
 	context.UePool.Store(ue.Supi, ue)
 }
 

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -588,7 +588,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	}
 
 	ue.RegistrationRequest = registrationRequest
-	ue.RegistrationType5GS = registrationRequest.GetRegistrationType5GS()
+	ue.SetRegistrationType5GS(registrationRequest.GetRegistrationType5GS())
 	switch ue.RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration:
 		ue.GmmLog.Debugf("RegistrationType: Initial Registration")
@@ -599,11 +599,11 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	case nasMessage.RegistrationType5GSEmergencyRegistration:
 		return fmt.Errorf("not Supportted RegistrationType: Emergency Registration")
 	case nasMessage.RegistrationType5GSReserved:
-		ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+		ue.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
 		ue.GmmLog.Debugf("RegistrationType: Reserved")
 	default:
 		ue.GmmLog.Debugf("RegistrationType: %v, chage state to InitialRegistration", ue.RegistrationType5GS)
-		ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+		ue.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
 	}
 
 	mobileIdentity5GSContents := registrationRequest.GetMobileIdentity5GSContents()
@@ -638,7 +638,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 			}
 		}
 		if guamiMatched {
-			ue.Guti = guti
+			ue.SetGuti(guti)
 			ue.ServingAmfChanged = false
 		} else {
 			ue.GmmLog.Warnf("GUAMI mismatch/not-served GUAMI from UE")
@@ -647,11 +647,11 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 		}
 	case nasMessage.MobileIdentity5GSTypeImei:
 		imei := nasConvert.PeiToString(mobileIdentity5GSContents)
-		ue.Pei = imei
+		ue.SetPei(imei)
 		ue.GmmLog.Debugf("PEI: %s", imei)
 	case nasMessage.MobileIdentity5GSTypeImeisv:
 		imeisv := nasConvert.PeiToString(mobileIdentity5GSContents)
-		ue.Pei = imeisv
+		ue.SetPei(imeisv)
 		ue.GmmLog.Debugf("PEI: %s", imeisv)
 	}
 
@@ -1687,7 +1687,7 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 		_, guti := nasConvert.GutiToString(mobileIdentityContents)
-		ue.Guti = guti
+		ue.SetGuti(guti)
 		ue.GmmLog.Debugf("get GUTI: %s", guti)
 	case nasMessage.MobileIdentity5GSType5gSTmsi:
 		if ue.MacFailed {
@@ -1697,7 +1697,7 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 		if tmp, err := strconv.ParseInt(sTmsi[4:], 10, 32); err != nil {
 			return err
 		} else {
-			ue.Tmsi = int32(tmp)
+			ue.SetTmsi(int32(tmp))
 		}
 		ue.GmmLog.Debugf("get 5G-S-TMSI: %s", sTmsi)
 	case nasMessage.MobileIdentity5GSTypeImei:
@@ -1705,14 +1705,14 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 		imei := nasConvert.PeiToString(mobileIdentityContents)
-		ue.Pei = imei
+		ue.SetPei(imei)
 		ue.GmmLog.Debugf("get PEI: %s", imei)
 	case nasMessage.MobileIdentity5GSTypeImeisv:
 		if ue.MacFailed {
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 		imeisv := nasConvert.PeiToString(mobileIdentityContents)
-		ue.Pei = imeisv
+		ue.SetPei(imeisv)
 		ue.GmmLog.Debugf("get PEI: %s", imeisv)
 	}
 	return nil
@@ -2352,7 +2352,7 @@ func HandleAuthenticationResponse(ctx ctxt.Context, ue *context.AmfUe, accessTyp
 		case models.AUTHRESULT_AUTHENTICATION_SUCCESS:
 			ue.UnauthenticatedSupi = false
 			ue.Kseaf = response.GetKseaf()
-			ue.Supi = response.GetSupi()
+			ue.SetSupi(response.GetSupi())
 			ue.DerivateKamf()
 			ue.GmmLog.Debugln("ue.DerivateKamf()", ue.Kamf)
 			return GmmFSM.SendEvent(ctx, ue.State[accessType], AuthSuccessEvent, fsm.ArgsType{
@@ -2386,7 +2386,7 @@ func HandleAuthenticationResponse(ctx ctxt.Context, ue *context.AmfUe, accessTyp
 		case models.AUTHRESULT_AUTHENTICATION_SUCCESS:
 			ue.UnauthenticatedSupi = false
 			ue.Kseaf = response.GetKSeaf()
-			ue.Supi = response.GetSupi()
+			ue.SetSupi(response.GetSupi())
 			ue.DerivateKamf()
 			// TODO: select enc/int algorithm based on ue security capability & amf's policy,
 			// then generate KnasEnc, KnasInt
@@ -2550,7 +2550,7 @@ func HandleSecurityModeComplete(ctx ctxt.Context, ue *context.AmfUe, anType mode
 
 	if securityModeComplete.IMEISV != nil {
 		ue.GmmLog.Debugln("receieve IMEISV")
-		ue.Pei = nasConvert.PeiToString(securityModeComplete.IMEISV.Octet[:])
+		ue.SetPei(nasConvert.PeiToString(securityModeComplete.IMEISV.Octet[:]))
 	}
 
 	// TODO: AMF shall set the NAS COUNTs to zero if horizontal derivation of KAMF is performed

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -1198,7 +1198,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 	amfUe.ReleaseCause[ran.AnType] = nil
 	switch ranUe.ReleaseAction {
 	case context.UeContextN2NormalRelease:
-		ran.Log.Infof("Release UE[%s] Context : N2 Connection Release", amfUe.Supi)
+		ran.Log.Infof("Release UE[%s] Context : N2 Connection Release", amfUe.GetSupi())
 		// amfUe.DetachRanUe(ran.AnType)
 		err := ranUe.Remove()
 		if err != nil {
@@ -1207,7 +1207,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 		amfUe.PublishUeCtxtInfo()
 		context.StoreContextInDB(amfUe)
 	case context.UeContextReleaseUeContext:
-		ran.Log.Infof("Release UE[%s] Context : Release Ue Context", amfUe.Supi)
+		ran.Log.Infof("Release UE[%s] Context : Release Ue Context", amfUe.GetSupi())
 		err := ranUe.Remove()
 		if err != nil {
 			ran.Log.Errorln(err.Error())
@@ -1215,7 +1215,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 
 		// Valid Security is not exist for this UE then only delete AMfUe Context
 		if !amfUe.SecurityContextAvailable {
-			ran.Log.Infof("Valid Security is not exist for the UE[%s], so deleting AmfUe Context", amfUe.Supi)
+			ran.Log.Infof("Valid Security is not exist for the UE[%s], so deleting AmfUe Context", amfUe.GetSupi())
 			amfUe.PublishUeCtxtInfo()
 			amfUe.Remove()
 			context.DeleteContextFromDB(amfUe)
@@ -1224,7 +1224,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 			context.StoreContextInDB(amfUe)
 		}
 	case context.UeContextReleaseDueToNwInitiatedDeregistraion:
-		ran.Log.Infof("Release UE[%s] Context Due to Nw Initiated: Release Ue Context", amfUe.Supi)
+		ran.Log.Infof("Release UE[%s] Context Due to Nw Initiated: Release Ue Context", amfUe.GetSupi())
 		err := ranUe.Remove()
 		if err != nil {
 			ran.Log.Errorln(err.Error())
@@ -1233,7 +1233,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 		amfUe.Remove()
 		context.DeleteContextFromDB(amfUe)
 	case context.UeContextReleaseHandover:
-		ran.Log.Infof("Release UE[%s] Context : Release for Handover", amfUe.Supi)
+		ran.Log.Infof("Release UE[%s] Context : Release for Handover", amfUe.GetSupi())
 		// TODO: it's a workaround, need to fix it.
 		targetRanUe := context.AMF_Self().RanUeFindByAmfUeNgapID(ranUe.TargetUe.AmfUeNgapId)
 
@@ -1675,7 +1675,7 @@ func HandleInitialUEMessage(ctx ctxt.Context, ran *context.AmfRan, message *ngap
 				ranUe.Log.Debugf("find AmfUe [GUTI: %s]", guti)
 				/* checking the guti-ue belongs to this amf instance */
 				if amfSelf.EnableDbStore {
-					id, err := amfSelf.Drsm.FindOwnerInt32ID(amfUe.Tmsi)
+					id, err := amfSelf.Drsm.FindOwnerInt32ID(amfUe.GetTmsi())
 					if err != nil {
 						ranUe.Log.Errorf("error checking the guti-ue in this instance: %v", err)
 					}
@@ -3290,7 +3290,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 		// Update NH
 		amfUe.UpdateNH()
 	} else {
-		ranUe.Log.Errorf("No Security Context : SUPI[%s]", amfUe.Supi)
+		ranUe.Log.Errorf("No Security Context : SUPI[%s]", amfUe.GetSupi())
 		ngap_message.SendPathSwitchRequestFailure(ran, sourceAMFUENGAPID.Value, rANUENGAPID.Value, nil, nil)
 		return
 	}

--- a/ngap/message/build.go
+++ b/ngap/message/build.go
@@ -1960,12 +1960,13 @@ func BuildPaging(
 
 	var amfID string
 	var tmsi string
-	if len(ue.Guti) == 19 {
-		amfID = ue.Guti[5:11]
-		tmsi = ue.Guti[11:]
+	guti := ue.GetGuti()
+	if len(guti) == 19 {
+		amfID = guti[5:11]
+		tmsi = guti[11:]
 	} else {
-		amfID = ue.Guti[6:12]
-		tmsi = ue.Guti[12:]
+		amfID = guti[6:12]
+		tmsi = guti[12:]
 	}
 	_, amfSetID, amfPointer := ngapConvert.AmfIdToNgap(amfID)
 
@@ -1990,7 +1991,7 @@ func BuildPaging(
 
 	taiListForPaging := ie.Value.TAIListForPaging
 	if ue.RegistrationArea[models.ACCESSTYPE__3_GPP_ACCESS] == nil {
-		err = fmt.Errorf("registration area of ue[%s] is empty", ue.Supi)
+		err = fmt.Errorf("registration area of ue[%s] is empty", ue.GetSupi())
 		return nil, err
 	} else {
 		for _, tai := range ue.RegistrationArea[models.ACCESSTYPE__3_GPP_ACCESS] {
@@ -2167,10 +2168,11 @@ func BuildRerouteNasRequest(ue *context.AmfUe, anType models.AccessType, amfUeNg
 	// <MCC><MNC> is 3 bytes, <AMF Region ID><AMF Set ID><AMF Pointer> is 3 bytes
 	// 1 byte is 2 characters
 	var amfID string
-	if len(ue.Guti) == 19 { // MNC is 2 char
-		amfID = ue.Guti[5:11]
+	guti := ue.GetGuti()
+	if len(guti) == 19 { // MNC is 2 char
+		amfID = guti[5:11]
 	} else {
-		amfID = ue.Guti[6:12]
+		amfID = guti[6:12]
 	}
 	_, amfSetID, _ := ngapConvert.AmfIdToNgap(amfID)
 

--- a/oam/api_purge_ue_context.go
+++ b/oam/api_purge_ue_context.go
@@ -49,7 +49,7 @@ func HTTPPurgeUEContext(c *gin.Context) {
 		reqUri := req.URL.RequestURI()
 		if ue, ok := amfSelf.AmfUeFindBySupi(supi); ok {
 			sbiMsg := context.SbiMsg{
-				UeContextId: ue.Supi,
+				UeContextId: ue.GetSupi(),
 				ReqUri:      reqUri,
 				Msg:         nil,
 				Result:      make(chan context.SbiResponseMsg, 10),

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -476,9 +476,9 @@ func HandleDeregistrationNotification(ctx ctxt.Context, request *httpwrapper.Req
 		if supi, exists := request.Params["supi"]; exists {
 			reqUri := request.URL.RequestURI()
 			if ue, ok := amfSelf.AmfUeFindBySupi(supi); ok {
-				logger.ProducerLog.Debugln("amf ue found: ", ue.Supi)
+				logger.ProducerLog.Debugln("amf ue found: ", ue.GetSupi())
 				sbiMsg := context.SbiMsg{
-					UeContextId: ue.Supi,
+					UeContextId: ue.GetSupi(),
 					ReqUri:      reqUri,
 					Msg:         nil,
 					Result:      make(chan context.SbiResponseMsg, 10),

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -90,7 +90,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 			ue := value.(*context.AmfUe)
 			ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
 			*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
-			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.Supi)
+			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			return true
 		})
 	} else if subscription.GetGroupId() != "" {
@@ -101,7 +101,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 			if ue.GroupID == subscription.GetGroupId() {
 				ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
 				*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
-				contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.Supi)
+				contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			}
 			return true
 		})
@@ -112,7 +112,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		} else {
 			ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
 			*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
-			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.Supi)
+			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 		}
 	}
 
@@ -322,7 +322,7 @@ func NewAmfEventReport(ue *context.AmfUe, Type models.AmfEventType, subscription
 	}
 
 	report.AnyUe = openapi.PtrBool(ueSubscription.AnyUe)
-	report.Supi = openapi.PtrString(ue.Supi)
+	report.Supi = openapi.PtrString(ue.GetSupi())
 	report.Type = Type
 	report.TimeStamp = ueSubscription.Timestamp
 	report.State = models.AmfEventState{}

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -74,10 +74,10 @@ func HandleOAMPurgeUEContextRequest(ctx ctxt.Context, supi, reqUri string, msg i
 		ueFsmState := ue.State[models.ACCESSTYPE__3_GPP_ACCESS].Current()
 		switch ueFsmState {
 		case context.Deregistered:
-			logger.ProducerLog.Info("Removing the UE : ", fmt.Sprintln(ue.Supi))
+			logger.ProducerLog.Info("Removing the UE : ", fmt.Sprintln(ue.GetSupi()))
 			ue.Remove()
 		case context.Registered:
-			logger.ProducerLog.Info("Deregistration triggered for the UE : ", ue.Supi)
+			logger.ProducerLog.Info("Deregistration triggered for the UE : ", ue.GetSupi())
 			err := gmm.GmmFSM.SendEvent(ctx, ue.State[models.ACCESSTYPE__3_GPP_ACCESS], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
 				gmm.ArgAmfUe:      ue,
 				gmm.ArgAccessType: models.ACCESSTYPE__3_GPP_ACCESS,
@@ -111,12 +111,12 @@ func HandleOAMActiveUEContextsFromDB(request *httpwrapper.Request) *httpwrapper.
 	for _, ue := range ueList {
 		ueContext := &ActiveUeContext{
 			AccessType: models.ACCESSTYPE__3_GPP_ACCESS,
-			Supi:       ue.Supi,
-			Guti:       ue.Guti,
+			Supi:       ue.GetSupi(),
+			Guti:       ue.GetGuti(),
 			Mcc:        ue.Tai.PlmnId.Mcc,
 			Mnc:        ue.Tai.PlmnId.Mnc,
 			Tac:        ue.Tai.Tac,
-			Tmsi:       fmt.Sprintf("%08x", ue.Tmsi),
+			Tmsi:       fmt.Sprintf("%08x", ue.GetTmsi()),
 		}
 		if ue.RanUe != nil && ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] != nil {
 			ueContext.RanUeNgapId = ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].RanUeNgapId
@@ -196,8 +196,8 @@ func buildUEContext(ue *context.AmfUe, accessType models.AccessType) *UEContext 
 	if ue.State[accessType].Is(context.Registered) {
 		ueContext := &UEContext{
 			AccessType: accessType,
-			Supi:       ue.Supi,
-			Guti:       ue.Guti,
+			Supi:       ue.GetSupi(),
+			Guti:       ue.GetGuti(),
 			Mcc:        ue.Tai.PlmnId.Mcc,
 			Mnc:        ue.Tai.PlmnId.Mnc,
 			Tac:        ue.Tai.Tac,

--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -422,15 +422,15 @@ func ueContextTransferProcedure(ueContextID string, ueContextTransferRequest mod
 
 func buildUEContextModel(ue *context.AmfUe) models.UeContext {
 	ueContext := models.NewUeContext()
-	ueContext.SetSupi(ue.Supi)
+	ueContext.SetSupi(ue.GetSupi())
 	ueContext.SetSupiUnauthInd(ue.UnauthenticatedSupi)
 
-	if ue.Gpsi != "" {
-		ueContext.GpsiList = append(ueContext.GpsiList, ue.Gpsi)
+	if gpsi := ue.GetGpsi(); gpsi != "" {
+		ueContext.GpsiList = append(ueContext.GpsiList, gpsi)
 	}
 
-	if ue.Pei != "" {
-		ueContext.SetPei(ue.Pei)
+	if pei := ue.GetPei(); pei != "" {
+		ueContext.SetPei(pei)
 	}
 
 	if ue.UdmGroupId != "" {


### PR DESCRIPTION
## Problem

The `AmfUe` identity fields — `Supi`, `Pei`, `Gpsi`, `Tmsi`, `Guti`, and `RegistrationType5GS` — are written by the UE's NAS procedure and read from other goroutines (SBI service handlers such as `Namf_Communication` and event exposure, OAM, the metrics/kafka context publish, and NGAP paging/downlink message builders) without any synchronization. That is a data race. A torn read of one of the `string` fields is a memory-safety hazard, not merely stale data.

`AmfUe.Mutex` exists, but today it only guards RanUe/CM state and is not taken by any of these identity-field accesses.

## Fix

Introduce a dedicated `identityMu sync.RWMutex` on `AmfUe` with `Get*`/`Set*` accessors and an `IdentitySnapshot()` helper. This mirrors the pattern already used elsewhere in the codebase — `AmfRan` (`ranStateMu` + snapshot methods) and `util/fsm.State` (internal `stateMutex` + `Get`/`Set`/`Is`). It is deliberately separate from `AmfUe.Mutex` so an accessor can never self-deadlock against code already holding `AmfUe.Mutex`.

- All writes to the identity fields now go through `Set*`.
- Cross-goroutine readers use `Get*` / `IdentitySnapshot`. Check-then-use sites (the GUTI length-then-slice, and the GPSI/PEI check-then-append when building a `models.UeContext`) snapshot into a local first, so a concurrent write cannot cause a torn or length-changing read.
- Same-goroutine NAS/registration reads (in `gmm`, and the outgoing SBI client calls made synchronously from the registration flow) are intentionally left as direct field access: they are serialized with the writers on the UE's own NAS goroutine and never raced, so converting them would only add lock traffic without any safety benefit.

## Tests

Adds `TestAmfUeIdentityConcurrentAccess` (in the `context` package): a writer goroutine and a reader goroutine hammer the identity fields concurrently and the test passes under `-race`. Replacing the accessor calls in the test with direct field access reproduces the failure, so it is a genuine regression test for the race.

## Validation

`go build ./...`, `go vet ./...`, and the reproducer under `-race` all pass on `linux/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
