### PR TITLE
fix: guard fixed-index access of external identity/NAS/NGAP input against panics

### DIFF
--- a/consumer/am_policy.go
+++ b/consumer/am_policy.go
@@ -7,6 +7,7 @@ package consumer
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -67,12 +68,21 @@ func AMPolicyControlCreate(ctx context.Context, ue *amf_context.AmfUe, anType mo
 	if localErr == nil {
 		locationHeader := httpResp.Header.Get("Location")
 		logger.ConsumerLog.Debugf("location header: %+v", locationHeader)
-		ue.AmPolicyUri = locationHeader
 
-		re := regexp.MustCompile("/policies/.*")
+		// Capture a non-empty path segment and stop at any query/fragment, so a
+		// bare ".../policies/" or a trailing "?x=1"/"#frag" cannot yield an empty
+		// or junk PolicyAssociationId that would poison later policy operations.
+		re := regexp.MustCompile(`/policies/([^/?#]+)`)
 		match := re.FindStringSubmatch(locationHeader)
+		if len(match) < 2 {
+			logger.ConsumerLog.Errorf("no PolicyAssociationId in AM policy Location header %q", locationHeader)
+			return nil, fmt.Errorf("no PolicyAssociationId in AM policy Location header %q", locationHeader)
+		}
 
-		ue.PolicyAssociationId = match[0][10:]
+		// Only record the URI once the Location header is known-valid, so a
+		// malformed header doesn't poison later AM policy update/terminate.
+		ue.AmPolicyUri = locationHeader
+		ue.PolicyAssociationId = match[1]
 		ue.AmPolicyAssociation = res
 
 		if res.Triggers != nil {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1503,7 +1503,7 @@ func handleRequestedNssai(ctx ctxt.Context, ue *context.AmfUe, registrationReque
 					// TargetAmfSet format: ^[0-9]{3}-[0-9]{2-3}-[A-Fa-f0-9]{2}-[0-3][A-Fa-f0-9]{2}$
 					// mcc-mnc-amfRegionId(8 bit)-AmfSetId(10 bit)
 					targetAmfSetToken := strings.Split(netwotkSliceInfo.GetTargetAmfSet(), "-")
-					if len(targetAmfSetToken) < 4 {
+					if len(targetAmfSetToken) != 4 {
 						ue.GmmLog.Errorf("invalid TargetAmfSet %q: want mcc-mnc-amfRegionId-amfSetId",
 							netwotkSliceInfo.GetTargetAmfSet())
 						return request

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -607,6 +607,9 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	}
 
 	mobileIdentity5GSContents := registrationRequest.GetMobileIdentity5GSContents()
+	if len(mobileIdentity5GSContents) == 0 {
+		return fmt.Errorf("empty MobileIdentity5GS contents in Registration Request")
+	}
 	ue.IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
 	switch ue.IdentityTypeUsedForRegistration { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeNoIdentity:
@@ -1500,6 +1503,11 @@ func handleRequestedNssai(ctx ctxt.Context, ue *context.AmfUe, registrationReque
 					// TargetAmfSet format: ^[0-9]{3}-[0-9]{2-3}-[A-Fa-f0-9]{2}-[0-3][A-Fa-f0-9]{2}$
 					// mcc-mnc-amfRegionId(8 bit)-AmfSetId(10 bit)
 					targetAmfSetToken := strings.Split(netwotkSliceInfo.GetTargetAmfSet(), "-")
+					if len(targetAmfSetToken) < 4 {
+						ue.GmmLog.Errorf("invalid TargetAmfSet %q: want mcc-mnc-amfRegionId-amfSetId",
+							netwotkSliceInfo.GetTargetAmfSet())
+						return request
+					}
 					guami := amfSelf.ServedGuamiList[0]
 					targetAmfPlmnId := models.PlmnId{
 						Mcc: targetAmfSetToken[0],
@@ -1666,6 +1674,9 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 	ue.GmmLog.Info("Handle Identity Response")
 
 	mobileIdentityContents := identityResponse.GetMobileIdentityContents()
+	if len(mobileIdentityContents) == 0 {
+		return fmt.Errorf("empty MobileIdentity contents in Identity Response")
+	}
 	switch nasConvert.GetTypeOfIdentity(mobileIdentityContents[0]) { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeSuci:
 		var plmnId string
@@ -1694,7 +1705,10 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 		sTmsi := hex.EncodeToString(mobileIdentityContents[1:])
-		if tmp, err := strconv.ParseInt(sTmsi[4:], 10, 32); err != nil {
+		if len(sTmsi) != 12 {
+			return fmt.Errorf("5G-S-TMSI has unexpected length in Identity Response (%d hex chars, want 12): %q", len(sTmsi), sTmsi)
+		}
+		if tmp, err := strconv.ParseInt(sTmsi[4:], 16, 32); err != nil {
 			return err
 		} else {
 			ue.SetTmsi(int32(tmp))

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1708,7 +1708,7 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 		if len(sTmsi) != 12 {
 			return fmt.Errorf("5G-S-TMSI has unexpected length in Identity Response (%d hex chars, want 12): %q", len(sTmsi), sTmsi)
 		}
-		if tmp, err := strconv.ParseInt(sTmsi[4:], 16, 32); err != nil {
+		if tmp, err := strconv.ParseUint(sTmsi[4:], 16, 32); err != nil {
 			return err
 		} else {
 			ue.SetTmsi(int32(tmp))

--- a/gmm/handler_test.go
+++ b/gmm/handler_test.go
@@ -1139,6 +1139,27 @@ func TestHandleIdentityResponseInvalidSuci(t *testing.T) {
 	}
 }
 
+// TestHandleIdentityResponse5GSTmsiFullRange: a 5G-TMSI is a full 32-bit value
+// (TS 23.003 2.10.1), so values with the high bit set (>= 0x80000000) must be
+// accepted; parsing them as signed 32-bit rejected them as out of range.
+func TestHandleIdentityResponse5GSTmsiFullRange(t *testing.T) {
+	ue := &context.AmfUe{
+		GmmLog: zap.NewNop().Sugar(),
+	}
+
+	identityResponse := nasMessage.NewIdentityResponse(0)
+	identityResponse.SetLen(7)
+	// type octet, 2-byte AMF Set ID + Pointer, 4-byte 5G-TMSI with high bit set
+	identityResponse.Buffer = []byte{nasMessage.MobileIdentity5GSType5gSTmsi, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff}
+
+	if err := HandleIdentityResponse(ue, identityResponse); err != nil {
+		t.Fatalf("HandleIdentityResponse with high-bit 5G-TMSI: unexpected error %v", err)
+	}
+	if got := uint32(ue.GetTmsi()); got != 0xffffffff {
+		t.Fatalf("stored 5G-TMSI = %#x, want 0xffffffff", got)
+	}
+}
+
 func TestPickDNN(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/nas/nas_security/security.go
+++ b/nas/nas_security/security.go
@@ -122,6 +122,10 @@ func FetchUeContextWithMobileIdentity(payload []byte) *context.AmfUe {
 	switch msg.SecurityHeaderType {
 	case nas.SecurityHeaderTypeIntegrityProtected:
 		logger.CommLog.Infoln("security header type: Integrity Protected")
+		if len(payload) < 7 {
+			logger.CommLog.Errorln("integrity protected NAS payload is too short")
+			return nil
+		}
 		p := payload[7:]
 		if err := msg.PlainNasDecode(&p); err != nil {
 			return nil
@@ -141,6 +145,10 @@ func FetchUeContextWithMobileIdentity(payload []byte) *context.AmfUe {
 	amfSelf := context.AMF_Self()
 	if msg.GmmHeader.GetMessageType() == nas.MsgTypeRegistrationRequest {
 		mobileIdentity5GSContents := msg.RegistrationRequest.GetMobileIdentity5GSContents()
+		if len(mobileIdentity5GSContents) == 0 {
+			logger.CommLog.Errorln("MobileIdentity5GSContents is empty in Registration Request")
+			return nil
+		}
 		if nasMessage.MobileIdentity5GSType5gGuti == nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0]) {
 			guami, guti = nasConvert.GutiToString(mobileIdentity5GSContents)
 			logger.CommLog.Debugf("Guti received in Registration Request Message: %v", guti)

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -5085,6 +5085,15 @@ func HandleCellTrafficTrace(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 	ranUe.Ran = ran
 	ran.Log.Debugf("UE: AmfUeNgapID[%d], RanUeNgapID[%d]", ranUe.AmfUeNgapId, ranUe.RanUeNgapId)
 
+	if nGRANTraceID == nil || nGRANCGI == nil || traceCollectionEntityIPAddress == nil {
+		ran.Log.Errorln("CellTrafficTrace missing NGRANTraceID, NGRANCGI, or TraceCollectionEntityIPAddress IE")
+		return
+	}
+	if len(nGRANTraceID.Value) != 8 {
+		ran.Log.Errorf("CellTrafficTrace NGRANTraceID has unexpected length (%d bytes, want 8)", len(nGRANTraceID.Value))
+		return
+	}
+
 	ranUe.Trsr = hex.EncodeToString(nGRANTraceID.Value[6:])
 
 	ranUe.Log.Debugf("TRSR[%s]", ranUe.Trsr)

--- a/ngap/message/build.go
+++ b/ngap/message/build.go
@@ -1926,16 +1926,21 @@ func BuildDownlinkRanStatusTransfer(ue *context.RanUe,
 // 5G-TMSI components. A GUTI is <MCC(3)><MNC(2|3)><AMF ID(6)><5G-TMSI(8)>, i.e.
 // 19 characters when the MNC has 2 digits and 20 when it has 3. Any other length
 // is rejected rather than sliced, which would otherwise panic on a short or empty
-// GUTI (e.g. a UE that has not yet been assigned one).
+// GUTI (e.g. a UE that has not yet been assigned one). The AMF ID and 5G-TMSI
+// are validated as hex, so callers can hex-decode them without a second check.
 func parseGuti(guti string) (amfID, tmsi string, err error) {
 	switch len(guti) {
 	case 19: // 2-digit MNC
-		return guti[5:11], guti[11:], nil
+		amfID, tmsi = guti[5:11], guti[11:]
 	case 20: // 3-digit MNC
-		return guti[6:12], guti[12:], nil
+		amfID, tmsi = guti[6:12], guti[12:]
 	default:
 		return "", "", fmt.Errorf("invalid GUTI length %d (want 19 or 20)", len(guti))
 	}
+	if _, err := hex.DecodeString(amfID + tmsi); err != nil {
+		return "", "", fmt.Errorf("invalid GUTI %q: AMF ID / 5G-TMSI is not hex: %w", guti, err)
+	}
+	return amfID, tmsi, nil
 }
 
 // pagingOriginNon3GPP: TS 23.502 4.2.3.3 step 4b: If the UE is simultaneously registered over

--- a/ngap/message/build.go
+++ b/ngap/message/build.go
@@ -1922,6 +1922,22 @@ func BuildDownlinkRanStatusTransfer(ue *context.RanUe,
 // Paging Priority: is included only if the AMF receives an Namf_Communication_N1N2MessageTransfer message
 // with an ARP value associated with
 // priority services (e.g., MPS, MCS), as configured by the operator. (TS 23.502 4.2.3.3, TS 23.501 5.22.3)
+// parseGuti splits a 5G GUTI string into its 6-hex-char AMF ID and 8-hex-char
+// 5G-TMSI components. A GUTI is <MCC(3)><MNC(2|3)><AMF ID(6)><5G-TMSI(8)>, i.e.
+// 19 characters when the MNC has 2 digits and 20 when it has 3. Any other length
+// is rejected rather than sliced, which would otherwise panic on a short or empty
+// GUTI (e.g. a UE that has not yet been assigned one).
+func parseGuti(guti string) (amfID, tmsi string, err error) {
+	switch len(guti) {
+	case 19: // 2-digit MNC
+		return guti[5:11], guti[11:], nil
+	case 20: // 3-digit MNC
+		return guti[6:12], guti[12:], nil
+	default:
+		return "", "", fmt.Errorf("invalid GUTI length %d (want 19 or 20)", len(guti))
+	}
+}
+
 // pagingOriginNon3GPP: TS 23.502 4.2.3.3 step 4b: If the UE is simultaneously registered over
 // 3GPP and non-3GPP accesses in the same PLMN,
 // the UE is in CM-IDLE state in both 3GPP access and non-3GPP access, and the PDU Session ID in step 3a
@@ -1958,19 +1974,12 @@ func BuildPaging(
 	uePagingIdentity.Present = ngapType.UEPagingIdentityPresentFiveGSTMSI
 	uePagingIdentity.FiveGSTMSI = new(ngapType.FiveGSTMSI)
 
-	var amfID string
-	var tmsi string
-	guti := ue.GetGuti()
-	if len(guti) == 19 {
-		amfID = guti[5:11]
-		tmsi = guti[11:]
-	} else {
-		amfID = guti[6:12]
-		tmsi = guti[12:]
+	amfID, tmsi, err := parseGuti(ue.GetGuti())
+	if err != nil {
+		return nil, fmt.Errorf("build Paging for ue[%s]: %w", ue.GetSupi(), err)
 	}
 	_, amfSetID, amfPointer := ngapConvert.AmfIdToNgap(amfID)
 
-	var err error
 	uePagingIdentity.FiveGSTMSI.AMFSetID.Value = amfSetID
 	uePagingIdentity.FiveGSTMSI.AMFPointer.Value = amfPointer
 	uePagingIdentity.FiveGSTMSI.FiveGTMSI.Value, err = hex.DecodeString(tmsi)
@@ -2167,12 +2176,9 @@ func BuildRerouteNasRequest(ue *context.AmfUe, anType models.AccessType, amfUeNg
 	// <MCC><MNC><AMF Region ID><AMF Set ID><AMF Pointer><5G-TMSI>
 	// <MCC><MNC> is 3 bytes, <AMF Region ID><AMF Set ID><AMF Pointer> is 3 bytes
 	// 1 byte is 2 characters
-	var amfID string
-	guti := ue.GetGuti()
-	if len(guti) == 19 { // MNC is 2 char
-		amfID = guti[5:11]
-	} else {
-		amfID = guti[6:12]
+	amfID, _, err := parseGuti(ue.GetGuti())
+	if err != nil {
+		return nil, fmt.Errorf("build RerouteNASRequest for ue[%s]: %w", ue.GetSupi(), err)
 	}
 	_, amfSetID, _ := ngapConvert.AmfIdToNgap(amfID)
 

--- a/ngap/message/build_test.go
+++ b/ngap/message/build_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2026 Intel Corporation
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
 // SPDX-License-Identifier: Apache-2.0
 
 package message
@@ -151,6 +152,8 @@ func TestParseGuti(t *testing.T) {
 		{name: "19 chars 2-digit MNC", guti: "208930000ff00000001", wantAmfID: "0000ff", wantTmsi: "00000001"},
 		{name: "20 chars 3-digit MNC", guti: "2089300000ff00000001", wantAmfID: "0000ff", wantTmsi: "00000001"},
 		{name: "21 chars", guti: "123456789012345678901", wantErr: true},
+		{name: "19 chars non-hex 5G-TMSI", guti: "208930000ff0000000g", wantErr: true},
+		{name: "20 chars non-hex AMF ID", guti: "20893000zzff00000001", wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ngap/message/build_test.go
+++ b/ngap/message/build_test.go
@@ -132,3 +132,50 @@ func buildSnssaiList(count int) []models.Snssai {
 	}
 	return list
 }
+
+// TestParseGuti covers the GUTI length validation that replaced the unguarded
+// fixed-index slicing in BuildPaging / BuildRerouteNasRequest. Only 19-char
+// (2-digit MNC) and 20-char (3-digit MNC) GUTIs are valid; anything else must
+// be rejected rather than sliced (which would panic).
+func TestParseGuti(t *testing.T) {
+	tests := []struct {
+		name      string
+		guti      string
+		wantErr   bool
+		wantAmfID string
+		wantTmsi  string
+	}{
+		{name: "empty", guti: "", wantErr: true},
+		{name: "far too short", guti: "12345", wantErr: true},
+		{name: "18 chars", guti: "123456789012345678", wantErr: true},
+		{name: "19 chars 2-digit MNC", guti: "208930000ff00000001", wantAmfID: "0000ff", wantTmsi: "00000001"},
+		{name: "20 chars 3-digit MNC", guti: "2089300000ff00000001", wantAmfID: "0000ff", wantTmsi: "00000001"},
+		{name: "21 chars", guti: "123456789012345678901", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			amfID, tmsi, err := parseGuti(tc.guti)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseGuti(%q): want error, got (%q, %q, nil)", tc.guti, amfID, tmsi)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGuti(%q): unexpected error %v", tc.guti, err)
+			}
+			if amfID != tc.wantAmfID || tmsi != tc.wantTmsi {
+				t.Fatalf("parseGuti(%q) = (%q, %q), want (%q, %q)", tc.guti, amfID, tmsi, tc.wantAmfID, tc.wantTmsi)
+			}
+		})
+	}
+}
+
+// TestBuildPagingRejectsInvalidGuti is the end-to-end regression for the panic:
+// a UE that has not been assigned a GUTI must make BuildPaging return an error
+// rather than panic while slicing ue.Guti.
+func TestBuildPagingRejectsInvalidGuti(t *testing.T) {
+	if _, err := BuildPaging(&context.AmfUe{}, nil, false); err == nil {
+		t.Fatal("BuildPaging with empty GUTI: want error, got nil")
+	}
+}

--- a/producer/n1n2message.go
+++ b/producer/n1n2message.go
@@ -377,7 +377,15 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 			pkg, err := ngap_message.BuildPaging(ue, pagingPriority, false)
 			if err != nil {
 				logger.NgapLog.Errorf("build paging failed: %s", err.Error())
-				return n1n2MessageTransferRspData, locationHeader, problemDetails, transferErr
+				// paging was never sent, so no T3513 will fire to clear the
+				// transient state set above; reset it so the UE is not left
+				// stuck in an OnGoingProcedurePaging conflict.
+				ue.N1N2Message = nil
+				ue.SetOnGoing(anType, &context.OnGoingProcedureWithPrio{
+					Procedure: context.OnGoingProcedureNothing,
+				})
+				problemDetails = utils.ProblemDetailsSystemFailure(err.Error())
+				return nil, "", problemDetails, nil
 			}
 			ngap_message.SendPaging(ue, pkg)
 		}
@@ -402,7 +410,11 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 				nasMsg, err := gmm_message.BuildNotification(ue, models.ACCESSTYPE_NON_3_GPP_ACCESS)
 				if err != nil {
 					logger.GmmLog.Errorf("build notification failed: %s", err.Error())
-					return n1n2MessageTransferRspData, locationHeader, problemDetails, transferErr
+					// notification was never sent; clear the transient state and
+					// surface the failure instead of replying 202 Accepted.
+					ue.N1N2Message = nil
+					problemDetails = utils.ProblemDetailsSystemFailure(err.Error())
+					return nil, "", problemDetails, nil
 				}
 				gmm_message.SendNotification(ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS], nasMsg)
 			}
@@ -429,6 +441,15 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 			pkg, err := ngap_message.BuildPaging(ue, pagingPriority, true)
 			if err != nil {
 				logger.NgapLog.Errorf("build paging failed: %s", err.Error())
+				// paging was never sent, so no T3513 will fire to clear the
+				// transient state set above; reset it so the UE is not left
+				// stuck in an OnGoingProcedurePaging conflict.
+				ue.N1N2Message = nil
+				ue.SetOnGoing(anType, &context.OnGoingProcedureWithPrio{
+					Procedure: context.OnGoingProcedureNothing,
+				})
+				problemDetails = utils.ProblemDetailsSystemFailure(err.Error())
+				return nil, "", problemDetails, nil
 			}
 			ngap_message.SendPaging(ue, pkg)
 			return n1n2MessageTransferRspData, locationHeader, nil, nil

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -116,7 +116,7 @@ func HandleOAMActiveUEContextsFromDB(request *httpwrapper.Request) *httpwrapper.
 			Mcc:        ue.Tai.PlmnId.Mcc,
 			Mnc:        ue.Tai.PlmnId.Mnc,
 			Tac:        ue.Tai.Tac,
-			Tmsi:       fmt.Sprintf("%08x", ue.GetTmsi()),
+			Tmsi:       fmt.Sprintf("%08x", uint32(ue.GetTmsi())),
 		}
 		if ue.RanUe != nil && ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] != nil {
 			ueContext.RanUeNgapId = ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].RanUeNgapId


### PR DESCRIPTION
## Problem

Several AMF handlers index or slice externally-sourced identifiers, NAS payloads, and NGAP IEs at **fixed offsets without first validating length or presence**. A malformed UE / RAN / peer-NF message — or simply a UE that has not yet been assigned a GUTI — can drive an out-of-range slice or a nil dereference and **panic the AMF**. Several are remotely triggerable by a single crafted NAS/NGAP message.

This came out of the review of #735, where the GUTI `ue.Guti[6:12]` slicing in `BuildPaging` was flagged and deferred to a focused follow-up. This PR fixes that instance and the broader class it belongs to.

## Fix

Validate length/presence before each fixed-index access.

| Area | Site | Guard |
|------|------|-------|
| `ngap/message/build.go` | `BuildPaging`, `BuildRerouteNasRequest` GUTI slicing | new `parseGuti()` rejects GUTIs that are not 19 (2-digit MNC) or 20 (3-digit MNC) chars; the builders return an error for an invalid/empty GUTI instead of panicking |
| `producer/n1n2message.go` | both Paging callers | logged the build error but fell through to `SendPaging` with a nil buffer — now return early **and surface a 5xx `ProblemDetails`** instead of the misleading `202 Accepted` |
| `gmm/handler.go` | Registration Request `MobileIdentity5GS[0]`; Identity Response `MobileIdentity[0]` and `sTmsi[4:]`; NSSF `TargetAmfSet` token split | reject empty contents / short 5G-S-TMSI / a split of fewer than 4 tokens; **also decode the 5G-S-TMSI as base-16** (was base-10, wrong for a hex string) |
| `nas/nas_security/security.go` | integrity-protected `payload[7:]`; Registration-branch `MobileIdentity5GS[0]` | reject a short payload; guard empty contents (mirrors the existing Deregistration-branch guard) |
| `ngap/handler.go` | `HandleCellTrafficTrace` — `NGRANTraceID.Value[6:]`, `NGRANCGI.Present`, `*TraceCollectionEntityIPAddress` | guard presence of the three optional IEs (+ `NGRANTraceID` length) and drop the message otherwise |
| `consumer/am_policy.go` | PCF `Location`-header regex `match[0][10:]` | guard a nil regex match |

Functions that return `error` return one; void handlers log and return.

### Review-driven correctness fixes

Two of the touched lines had pre-existing behavioral bugs (flagged by Copilot); fixed here since the code was already being changed:

- **`producer/n1n2message.go`** — on a paging-build failure both callers now return a 5xx `ProblemDetails` (`utils.ProblemDetailsSystemFailure`) rather than a nil that the handler reports as `202 Accepted`.
- **`gmm/handler.go`** — the 5G-S-TMSI was parsed with `strconv.ParseInt(sTmsi[4:], 10, 32)` (base 10 on a hex string); now base 16, which round-trips with the `fmt.Sprintf("%08x", tmsi)` encoding used when the TMSI is allocated. The length guard is also tightened so the `sTmsi[4:]` slice can't be empty.

## Intentionally out of scope

**Config-derived** index reads (an empty `ServedGuamiList`, a short config `AmfId`) are left as-is: an unset served-GUAMI list is a start-up misconfiguration rather than attacker-reachable runtime input, and is better handled by config validation than by scattered runtime guards. Happy to add those here if you'd prefer.

Two upstream libraries (`nasConvert.GutiToString`/`GutiToNas`, `ngapConvert.AmfIdToNgap`) also slice fixed offsets and can panic on short input; the AMF-side fix is to validate before calling them — hardening the libraries themselves belongs in their own repos.

## Tests

- `parseGuti` unit test (empty / far-too-short / 18 / 19 / 20 / over-length).
- Regression test: `BuildPaging` on a UE with no GUTI returns an error rather than panicking.

## Coordination

This touches `ngap/handler.go` like #731, but a **different handler** — `HandleCellTrafficTrace` — so there is no overlap. The sibling PRs from the same review (#735, #739) have since merged; this branch is rebased on current `main`.

## Verification

`golangci-lint v2.11.3` with `.golangci.yml` → **0 issues**; `go build ./...` and `go vet ./...` clean; `go test ./ngap/message/` passes — all run in the `linux/amd64` container.
