### PR TITLE
refactor: route AmfUe identity reads through the Get* accessors (follow-up to #735)

### DIFF
--- a/consumer/am_policy.go
+++ b/consumer/am_policy.go
@@ -26,7 +26,7 @@ func AMPolicyControlCreate(ctx context.Context, ue *amf_context.AmfUe, anType mo
 		attribute.String("http.method", "POST"),
 		attribute.String("nf.target", "pcf"),
 		attribute.String("net.peer.name", ue.PcfUri),
-		attribute.String("ue.supi", ue.Supi),
+		attribute.String("ue.supi", ue.GetSupi()),
 		attribute.String("ue.plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -42,16 +42,16 @@ func AMPolicyControlCreate(ctx context.Context, ue *amf_context.AmfUe, anType mo
 
 	policyAssociationRequest := models.PolicyAssociationRequest{
 		NotificationUri: amfSelf.GetIPv4Uri() + "/namf-callback/v1/am-policy/",
-		Supi:            ue.Supi,
+		Supi:            ue.GetSupi(),
 		AccessType:      &anType,
 		ServingPlmn:     models.NewPlmnIdNid(ue.PlmnId.GetMcc(), ue.PlmnId.GetMnc()),
 		Guami:           &amfSelf.ServedGuamiList[0],
 	}
-	if ue.Pei != "" {
-		policyAssociationRequest.Pei = openapi.PtrString(ue.Pei)
+	if ue.GetPei() != "" {
+		policyAssociationRequest.Pei = openapi.PtrString(ue.GetPei())
 	}
-	if ue.Gpsi != "" {
-		policyAssociationRequest.Gpsi = openapi.PtrString(ue.Gpsi)
+	if ue.GetGpsi() != "" {
+		policyAssociationRequest.Gpsi = openapi.PtrString(ue.GetGpsi())
 	}
 
 	if ue.AccessAndMobilitySubscriptionData != nil {
@@ -112,7 +112,7 @@ func AMPolicyControlUpdate(ctx context.Context, ue *amf_context.AmfUe, updateReq
 		attribute.String("http.method", "POST"),
 		attribute.String("nf.target", "pcf"),
 		attribute.String("net.peer.name", ue.PcfUri),
-		attribute.String("ue.supi", ue.Supi),
+		attribute.String("ue.supi", ue.GetSupi()),
 		attribute.String("ue.plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -172,7 +172,7 @@ func AMPolicyControlDelete(ctx context.Context, ue *amf_context.AmfUe) (problemD
 		attribute.String("http.method", "DELETE"),
 		attribute.String("nf.target", "pcf"),
 		attribute.String("net.peer.name", ue.PcfUri),
-		attribute.String("ue.supi", ue.Supi),
+		attribute.String("ue.supi", ue.GetSupi()),
 		attribute.String("ue.plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 

--- a/consumer/communication.go
+++ b/consumer/communication.go
@@ -24,15 +24,15 @@ import (
 )
 
 func BuildUeContextModel(ue *amf_context.AmfUe) (ueContext models.UeContext) {
-	ueContext.Supi = openapi.PtrString(ue.Supi)
+	ueContext.Supi = openapi.PtrString(ue.GetSupi())
 	ueContext.SupiUnauthInd = openapi.PtrBool(ue.UnauthenticatedSupi)
 
-	if ue.Gpsi != "" {
-		ueContext.GpsiList = append(ueContext.GpsiList, ue.Gpsi)
+	if ue.GetGpsi() != "" {
+		ueContext.GpsiList = append(ueContext.GpsiList, ue.GetGpsi())
 	}
 
-	if ue.Pei != "" {
-		ueContext.Pei = openapi.PtrString(ue.Pei)
+	if ue.GetPei() != "" {
+		ueContext.Pei = openapi.PtrString(ue.GetPei())
 	}
 
 	if ue.UdmGroupId != "" {
@@ -114,7 +114,7 @@ func UEContextTransferRequest(
 		attribute.String("http.method", "POST"),
 		attribute.String("nf.target", "amf"),
 		attribute.String("net.peer.name", ue.TargetAmfUri),
-		attribute.String("ue.supi", ue.Supi),
+		attribute.String("ue.supi", ue.GetSupi()),
 		attribute.String("ue.plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -143,7 +143,7 @@ func UEContextTransferRequest(
 	}
 
 	// guti format is defined at TS 29.518 Table 6.1.3.2.2-1 5g-guti-[0-9]{5,6}[0-9a-fA-F]{14}
-	ueContextId := fmt.Sprintf("5g-guti-%s", ue.Guti)
+	ueContextId := fmt.Sprintf("5g-guti-%s", ue.GetGuti())
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -207,7 +207,7 @@ func RegistrationStatusUpdate(ctx context.Context, ue *amf_context.AmfUe, reques
 		attribute.String("http.method", "POST"),
 		attribute.String("nf.target", "amf"),
 		attribute.String("net.peer.name", ue.TargetAmfUri),
-		attribute.String("ue.supi", ue.Supi),
+		attribute.String("ue.supi", ue.GetSupi()),
 		attribute.String("ue.plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -222,7 +222,7 @@ func RegistrationStatusUpdate(ctx context.Context, ue *amf_context.AmfUe, reques
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	ueContextId := fmt.Sprintf("5g-guti-%s", ue.Guti)
+	ueContextId := fmt.Sprintf("5g-guti-%s", ue.GetGuti())
 	apiRegistrationStatusUpdateRequest := client.IndividualUeContextDocumentAPI.RegistrationStatusUpdate(ctx, ueContextId)
 	apiRegistrationStatusUpdateRequest = apiRegistrationStatusUpdateRequest.UeRegStatusUpdateReqData(request)
 	res, httpResp, localErr := client.IndividualUeContextDocumentAPI.RegistrationStatusUpdateExecute(apiRegistrationStatusUpdateRequest)

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -274,10 +274,10 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 	requestType *models.RequestType,
 ) (smContextCreateData models.SmContextCreateData) {
 	context := amf_context.AMF_Self()
-	smContextCreateData.SetSupi(ue.Supi)
+	smContextCreateData.SetSupi(ue.GetSupi())
 	smContextCreateData.SetUnauthenticatedSupi(ue.UnauthenticatedSupi)
-	smContextCreateData.SetPei(ue.Pei)
-	smContextCreateData.SetGpsi(ue.Gpsi)
+	smContextCreateData.SetPei(ue.GetPei())
+	smContextCreateData.SetGpsi(ue.GetGpsi())
 	smContextCreateData.SetPduSessionId(smContext.PduSessionID())
 	smContextCreateData.SetSNssai(smContext.Snssai())
 	smContextCreateData.SetDnn(smContext.Dnn())
@@ -305,7 +305,7 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 	smContextCreateData.SetUeLocation(ue.Location)
 	smContextCreateData.SetUeTimeZone(ue.TimeZone)
 	smContextCreateData.SetSmContextStatusUri(context.GetIPv4Uri() + "/namf-callback/v1/smContextStatus/" +
-		ue.Guti + "/" + strconv.Itoa(int(smContext.PduSessionID())))
+		ue.GetGuti() + "/" + strconv.Itoa(int(smContext.PduSessionID())))
 
 	return smContextCreateData
 }

--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -28,7 +28,7 @@ func PutUpuAck(ctx context.Context, ue *amf_context.AmfUe, upuMacIue string) err
 		attribute.String("http.method", "PUT"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 		attribute.String("upu.mac.iue", upuMacIue),
 	)
@@ -47,7 +47,7 @@ func PutUpuAck(ctx context.Context, ue *amf_context.AmfUe, upuMacIue string) err
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	apiUpuAckRequest := client.ProvidingAcknowledgementOfUEParametersUpdateAPI.UpuAck(ctx, ue.Supi)
+	apiUpuAckRequest := client.ProvidingAcknowledgementOfUEParametersUpdateAPI.UpuAck(ctx, ue.GetSupi())
 	apiUpuAckRequest = apiUpuAckRequest.AcknowledgeInfo(ackInfo)
 	_, err := client.ProvidingAcknowledgementOfUEParametersUpdateAPI.UpuAckExecute(apiUpuAckRequest)
 	return err
@@ -61,7 +61,7 @@ func SDMGetAmData(ctx context.Context, ue *amf_context.AmfUe) (problemDetails *m
 		attribute.String("http.method", "GET"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -78,7 +78,7 @@ func SDMGetAmData(ctx context.Context, ue *amf_context.AmfUe) (problemDetails *m
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	apiGetAmDataRequest := client.AccessAndMobilitySubscriptionDataRetrievalAPI.GetAmData(ctx, ue.Supi)
+	apiGetAmDataRequest := client.AccessAndMobilitySubscriptionDataRetrievalAPI.GetAmData(ctx, ue.GetSupi())
 	apiGetAmDataRequest = apiGetAmDataRequest.PlmnId(*plmnId)
 	data, httpResp, localErr := client.AccessAndMobilitySubscriptionDataRetrievalAPI.GetAmDataExecute(apiGetAmDataRequest)
 	if localErr == nil {
@@ -112,7 +112,7 @@ func SDMGetSmfSelectData(ctx context.Context, ue *amf_context.AmfUe) (problemDet
 		attribute.String("http.method", "GET"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -127,7 +127,7 @@ func SDMGetSmfSelectData(ctx context.Context, ue *amf_context.AmfUe) (problemDet
 	plmnId := models.NewPlmnId(ue.PlmnId.Mcc, ue.PlmnId.Mnc)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	apiGetSmfSelDataRequest := client.SMFSelectionSubscriptionDataRetrievalAPI.GetSmfSelData(ctx, ue.Supi)
+	apiGetSmfSelDataRequest := client.SMFSelectionSubscriptionDataRetrievalAPI.GetSmfSelData(ctx, ue.GetSupi())
 	apiGetSmfSelDataRequest = apiGetSmfSelDataRequest.PlmnId(*plmnId)
 	data, httpResp, localErr := client.SMFSelectionSubscriptionDataRetrievalAPI.GetSmfSelDataExecute(apiGetSmfSelDataRequest)
 	if localErr == nil {
@@ -157,7 +157,7 @@ func SDMGetUeContextInSmfData(ctx context.Context, ue *amf_context.AmfUe) (probl
 		attribute.String("http.method", "GET"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -171,7 +171,7 @@ func SDMGetUeContextInSmfData(ctx context.Context, ue *amf_context.AmfUe) (probl
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	apiGetUeCtxInSmfDataRequest := client.UEContextInSMFDataRetrievalAPI.GetUeCtxInSmfData(ctx, ue.Supi)
+	apiGetUeCtxInSmfDataRequest := client.UEContextInSMFDataRetrievalAPI.GetUeCtxInSmfData(ctx, ue.GetSupi())
 	data, httpResp, localErr := client.UEContextInSMFDataRetrievalAPI.GetUeCtxInSmfDataExecute(apiGetUeCtxInSmfDataRequest)
 	if localErr == nil {
 		ue.UeContextInSmfData = data
@@ -200,7 +200,7 @@ func SDMSubscribe(ctx context.Context, ue *amf_context.AmfUe) (problemDetails *m
 		attribute.String("http.method", "POST"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -220,7 +220,7 @@ func SDMSubscribe(ctx context.Context, ue *amf_context.AmfUe) (problemDetails *m
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	apiSubscribeRequest := client.SubscriptionCreationAPI.Subscribe(ctx, ue.Supi)
+	apiSubscribeRequest := client.SubscriptionCreationAPI.Subscribe(ctx, ue.GetSupi())
 	apiSubscribeRequest = apiSubscribeRequest.SdmSubscription(sdmSubscription)
 	_, httpResp, localErr := client.SubscriptionCreationAPI.SubscribeExecute(apiSubscribeRequest)
 	if localErr == nil {
@@ -249,7 +249,7 @@ func SDMGetSliceSelectionSubscriptionData(ctx context.Context, ue *amf_context.A
 		attribute.String("http.method", "GET"),
 		attribute.String("nf.target", "udm"),
 		attribute.String("net.peer.name", ue.NudmSDMUri),
-		attribute.String("udm.supi", ue.Supi),
+		attribute.String("udm.supi", ue.GetSupi()),
 		attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 	)
 
@@ -264,7 +264,7 @@ func SDMGetSliceSelectionSubscriptionData(ctx context.Context, ue *amf_context.A
 	plmnId := models.NewPlmnId(ue.PlmnId.Mcc, ue.PlmnId.Mnc)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	apiGetNSSAIRequest := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAI(ctx, ue.Supi)
+	apiGetNSSAIRequest := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAI(ctx, ue.GetSupi())
 	apiGetNSSAIRequest = apiGetNSSAIRequest.PlmnId(*plmnId)
 	nssai, httpResp, localErr := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAIExecute(apiGetNSSAIRequest)
 	if localErr == nil {

--- a/consumer/ue_context_management.go
+++ b/consumer/ue_context_management.go
@@ -65,11 +65,11 @@ func UeCmRegistration(ctx context.Context, ue *amf_context.AmfUe, accessType mod
 			attribute.String("http.method", "PUT"),
 			attribute.String("nf.target", "udm"),
 			attribute.String("net.peer.name", ue.NudmUECMUri),
-			attribute.String("udm.supi", ue.Supi),
+			attribute.String("udm.supi", ue.GetSupi()),
 			attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 		)
 
-		apiCall3GppRegistrationRequest := client.AMFRegistrationFor3GPPAccessAPI.Call3GppRegistration(gppAccessCtx, ue.Supi)
+		apiCall3GppRegistrationRequest := client.AMFRegistrationFor3GPPAccessAPI.Call3GppRegistration(gppAccessCtx, ue.GetSupi())
 		apiCall3GppRegistrationRequest = apiCall3GppRegistrationRequest.Amf3GppAccessRegistration(registrationData)
 		_, httpResp, localErr := client.AMFRegistrationFor3GPPAccessAPI.Call3GppRegistrationExecute(apiCall3GppRegistrationRequest)
 		if localErr == nil {
@@ -104,11 +104,11 @@ func UeCmRegistration(ctx context.Context, ue *amf_context.AmfUe, accessType mod
 			attribute.String("http.method", "PUT"),
 			attribute.String("nf.target", "udm"),
 			attribute.String("net.peer.name", ue.NudmUECMUri),
-			attribute.String("udm.supi", ue.Supi),
+			attribute.String("udm.supi", ue.GetSupi()),
 			attribute.String("plmn.id", ue.PlmnId.Mcc+ue.PlmnId.Mnc),
 		)
 
-		apiNon3GppRegistrationRequest := client.AMFRegistrationForNon3GPPAccessAPI.Non3GppRegistration(non3gppAccessCtx, ue.Supi)
+		apiNon3GppRegistrationRequest := client.AMFRegistrationForNon3GPPAccessAPI.Non3GppRegistration(non3gppAccessCtx, ue.GetSupi())
 		apiNon3GppRegistrationRequest = apiNon3GppRegistrationRequest.AmfNon3GppAccessRegistration(registrationData)
 		_, httpResp, localErr := client.AMFRegistrationForNon3GPPAccessAPI.Non3GppRegistrationExecute(apiNon3GppRegistrationRequest)
 		if localErr == nil {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -354,7 +354,7 @@ func releaseDuplicatePDUSession(
 		Release: openapi.PtrBool(true),
 		Cause:   models.CAUSE_REL_DUE_TO_DUPLICATE_SESSION_ID.Ptr(),
 		SmContextStatusUri: openapi.PtrString(fmt.Sprintf("%s/namf-callback/v1/smContextStatus/%s/%d",
-			ue.ServingAMF.GetIPv4Uri(), ue.Guti, pduID)),
+			ue.ServingAMF.GetIPv4Uri(), ue.GetGuti(), pduID)),
 	}
 	ue.GmmLog.Warnf("duplicated PDU session ID[%d]", pduID)
 	smCtx.SetDuplicatedPduSessionID(true)
@@ -436,7 +436,7 @@ func forward5GSMMessageToSMF(
 	smContextUpdateData := models.SmContextUpdateData{
 		N1SmMsg: n1SmMsg,
 	}
-	smContextUpdateData.Pei = openapi.PtrString(ue.Pei)
+	smContextUpdateData.Pei = openapi.PtrString(ue.GetPei())
 	if !context.CompareUserLocation(ue.Location, smContext.UserLocation()) {
 		smContextUpdateData.UeLocation = &ue.Location
 	}
@@ -589,7 +589,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 
 	ue.RegistrationRequest = registrationRequest
 	ue.SetRegistrationType5GS(registrationRequest.GetRegistrationType5GS())
-	switch ue.RegistrationType5GS {
+	switch ue.GetRegistrationType5GS() {
 	case nasMessage.RegistrationType5GSInitialRegistration:
 		ue.GmmLog.Debugf("RegistrationType: Initial Registration")
 	case nasMessage.RegistrationType5GSMobilityRegistrationUpdating:
@@ -602,7 +602,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 		ue.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
 		ue.GmmLog.Debugf("RegistrationType: Reserved")
 	default:
-		ue.GmmLog.Debugf("RegistrationType: %v, chage state to InitialRegistration", ue.RegistrationType5GS)
+		ue.GmmLog.Debugf("RegistrationType: %v, chage state to InitialRegistration", ue.GetRegistrationType5GS())
 		ue.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
 	}
 
@@ -729,7 +729,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	// to old AMF, including the complete registration request nas msg, to request UE's SUPI & UE Context
 	if ue.ServingAmfChanged {
 		var transferReason models.TransferReason
-		switch ue.RegistrationType5GS {
+		switch ue.GetRegistrationType5GS() {
 		case nasMessage.RegistrationType5GSInitialRegistration:
 			transferReason = models.TRANSFERREASON_INIT_REG
 		case nasMessage.RegistrationType5GSMobilityRegistrationUpdating:
@@ -765,7 +765,7 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 }
 
 func IdentityVerification(ue *context.AmfUe) bool {
-	return ue.Supi != "" || len(ue.Suci) != 0
+	return ue.GetSupi() != "" || len(ue.Suci) != 0
 }
 
 func HandleInitialRegistration(ctx ctxt.Context, ue *context.AmfUe, anType models.AccessType) error {
@@ -864,7 +864,7 @@ func HandleInitialRegistration(ctx ctxt.Context, ue *context.AmfUe, anType model
 	}
 
 	configureSearchPCFRequest := func(request Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) Nnrf_NFDiscovery.ApiSearchNFInstancesRequest {
-		return request.Supi(ue.Supi)
+		return request.Supi(ue.GetSupi())
 	}
 	for {
 		resp, err := sendSearchNFInstancesForRegistration(ctx, amfSelf.NrfUri, models.NFTYPE_PCF, models.NFTYPE_AMF, configureSearchPCFRequest)
@@ -926,11 +926,11 @@ func HandleInitialRegistration(ctx ctxt.Context, ue *context.AmfUe, anType model
 	// }
 
 	amfSelf.AllocateRegistrationArea(ue, anType)
-	ue.GmmLog.Debugf("Use original GUTI[%s]", ue.Guti)
+	ue.GmmLog.Debugf("Use original GUTI[%s]", ue.GetGuti())
 
 	assignLadnInfoForRegistration(ue, registrationRequest, anType)
 
-	amfSelf.AddAmfUeToUePool(ue, ue.Supi)
+	amfSelf.AddAmfUeToUePool(ue, ue.GetSupi())
 	ue.T3502Value = amfSelf.T3502Value
 	if anType == models.ACCESSTYPE__3_GPP_ACCESS {
 		ue.T3512Value = amfSelf.T3512Value
@@ -990,7 +990,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx ctxt.Context, ue *context
 	if registrationRequest.Capability5GMM != nil {
 		ue.Capability5GMM = *registrationRequest.Capability5GMM
 	} else {
-		if ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
+		if ue.GetRegistrationType5GS() != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
 			gmm_message.SendRegistrationReject(ue.RanUe[anType], nasMessage.Cause5GMMProtocolErrorUnspecified, "")
 			return fmt.Errorf("Capability5GMM is nil")
 		}
@@ -1011,7 +1011,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx ctxt.Context, ue *context
 	// 	If the AMF has changed the new AMF notifies the old AMF that the registration of the UE in the new AMF is completed
 	// }
 
-	if len(ue.Pei) == 0 {
+	if len(ue.GetPei()) == 0 {
 		gmm_message.SendIdentityRequest(ue.RanUe[anType], nasMessage.MobileIdentity5GSTypeImei)
 		return nil
 	}
@@ -1355,7 +1355,7 @@ func communicateWithUDM(ctx ctxt.Context, ue *context.AmfUe, accessType models.A
 	// UDM selection described in TS 23.501 6.3.8
 	// TODO: consider udm group id, Routing ID part of SUCI, GPSI or External Group ID (e.g., by the NEF)
 	configureSearchUDMRequest := func(request Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) Nnrf_NFDiscovery.ApiSearchNFInstancesRequest {
-		return request.Supi(ue.Supi)
+		return request.Supi(ue.GetSupi())
 	}
 	resp, err := consumer.SendSearchNFInstances(ctx, amfSelf.NrfUri, models.NFTYPE_UDM, models.NFTYPE_AMF, configureSearchUDMRequest)
 	if err != nil {
@@ -1419,7 +1419,7 @@ func communicateWithUDM(ctx ctxt.Context, ue *context.AmfUe, accessType models.A
 func getSubscribedNssai(ctx ctxt.Context, ue *context.AmfUe) {
 	amfSelf := context.AMF_Self()
 	configureSearchUDMRequest := func(request Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) Nnrf_NFDiscovery.ApiSearchNFInstancesRequest {
-		return request.Supi(ue.Supi)
+		return request.Supi(ue.GetSupi())
 	}
 	for {
 		err := consumer.SearchUdmSdmInstance(ctx, ue, amfSelf.NrfUri, models.NFTYPE_UDM, models.NFTYPE_AMF, configureSearchUDMRequest)
@@ -1923,7 +1923,7 @@ func HandleServiceRequest(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 	// Send Authtication / Security Procedure not support
 	// Rejecting ServiceRequest if it is received in Deregistered State
 	if !ue.SecurityContextIsValid() || ue.State[anType].Current() == context.Deregistered {
-		ue.GmmLog.Warnf("no security context: SUPI[%s]", ue.Supi)
+		ue.GmmLog.Warnf("no security context: SUPI[%s]", ue.GetSupi())
 		gmm_message.SendServiceReject(ue.RanUe[anType], nil, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 		ngap_message.SendUEContextReleaseCommand(ue.RanUe[anType],
 			context.UeContextN2NormalRelease, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
@@ -1977,7 +1977,7 @@ func HandleServiceRequest(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 
 	if ue.MacFailed {
 		ue.SecurityContextAvailable = false
-		ue.GmmLog.Warnf("security context exists but integrity check failed with existing context: SUPI[%s]", ue.Supi)
+		ue.GmmLog.Warnf("security context exists but integrity check failed with existing context: SUPI[%s]", ue.GetSupi())
 		gmm_message.SendServiceReject(ue.RanUe[anType], nil, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 		ngap_message.SendUEContextReleaseCommand(ue.RanUe[anType],
 			context.UeContextN2NormalRelease, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)

--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -375,7 +375,7 @@ func BuildSecurityModeCommand(ue *context.AmfUe, anType models.AccessType, eapSu
 	securityModeCommand.ReplayedUESecurityCapabilities.SetLen(ue.UESecurityCapability.GetLen())
 	securityModeCommand.ReplayedUESecurityCapabilities.Buffer = ue.UESecurityCapability.Buffer
 
-	if ue.Pei != "" {
+	if ue.GetPei() != "" {
 		securityModeCommand.IMEISVRequest = nasType.NewIMEISVRequest(nasMessage.SecurityModeCommandIMEISVRequestType)
 		securityModeCommand.SetIMEISVRequestValue(nasMessage.IMEISVNotRequested)
 	} else {
@@ -391,8 +391,8 @@ func BuildSecurityModeCommand(ue *context.AmfUe, anType models.AccessType, eapSu
 		securityModeCommand.SetRINMR(0)
 	}
 
-	if ue.RegistrationType5GS == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating ||
-		ue.RegistrationType5GS == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
+	if ue.GetRegistrationType5GS() == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating ||
+		ue.GetRegistrationType5GS() == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
 		securityModeCommand.SetHDP(1)
 	} else {
 		securityModeCommand.SetHDP(0)
@@ -527,8 +527,8 @@ func BuildRegistrationAccept(
 	registrationAccept.SetRegistrationResultValue5GS(registrationResult)
 	// TODO: set smsAllowed value of RegistrationResult5GS if need
 
-	if ue.Guti != "" {
-		gutiNas := nasConvert.GutiToNas(ue.Guti)
+	if ue.GetGuti() != "" {
+		gutiNas := nasConvert.GutiToNas(ue.GetGuti())
 		registrationAccept.GUTI5G = &gutiNas
 		registrationAccept.GUTI5G.SetIei(nasMessage.RegistrationAcceptGUTI5GType)
 	}
@@ -701,8 +701,8 @@ func BuildConfigurationUpdateCommand(ue *context.AmfUe, anType models.AccessType
 		configurationUpdateCommand.NetworkSlicingIndication = networkSlicingIndication
 	}
 
-	if ue.Guti != "" {
-		gutiNas := nasConvert.GutiToNas(ue.Guti)
+	if ue.GetGuti() != "" {
+		gutiNas := nasConvert.GutiToNas(ue.GetGuti())
 		configurationUpdateCommand.GUTI5G = &gutiNas
 		configurationUpdateCommand.GUTI5G.SetIei(nasMessage.ConfigurationUpdateCommandGUTI5GType)
 	}

--- a/gmm/sm.go
+++ b/gmm/sm.go
@@ -263,10 +263,10 @@ func SecurityMode(ctx ctxt.Context, state *fsm.State, event fsm.EventType, args 
 		amfUe := args[ArgAmfUe].(*context.AmfUe)
 		accessType := args[ArgAccessType].(models.AccessType)
 		// set log information
-		amfUe.NASLog = amfUe.NASLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.Supi))
-		amfUe.TxLog = amfUe.NASLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.Supi))
-		amfUe.GmmLog = amfUe.GmmLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.Supi))
-		amfUe.ProducerLog = logger.ProducerLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.Supi))
+		amfUe.NASLog = amfUe.NASLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.GetSupi()))
+		amfUe.TxLog = amfUe.NASLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.GetSupi()))
+		amfUe.GmmLog = amfUe.GmmLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.GetSupi()))
+		amfUe.ProducerLog = logger.ProducerLog.With(logger.FieldSupi, fmt.Sprintf("SUPI:%s", amfUe.GetSupi()))
 		amfUe.PublishUeCtxtInfo()
 		amfUe.GmmLog.Debugln("EntryEvent at GMM State[SecurityMode]")
 		if amfUe.SecurityContextIsValid() {
@@ -406,7 +406,7 @@ func ContextSetup(ctx ctxt.Context, state *fsm.State, event fsm.EventType, args 
 		switch message := gmmMessage.(type) {
 		case *nasMessage.RegistrationRequest:
 			amfUe.RegistrationRequest = message
-			switch amfUe.RegistrationType5GS {
+			switch amfUe.GetRegistrationType5GS() {
 			case nasMessage.RegistrationType5GSInitialRegistration:
 				if err := HandleInitialRegistration(ctx, amfUe, accessType); err != nil {
 					logger.GmmLog.Errorln(err)
@@ -447,7 +447,7 @@ func ContextSetup(ctx ctxt.Context, state *fsm.State, event fsm.EventType, args 
 			if err := HandleIdentityResponse(amfUe, gmmMessage.IdentityResponse); err != nil {
 				logger.GmmLog.Errorln(err)
 			}
-			switch amfUe.RegistrationType5GS {
+			switch amfUe.GetRegistrationType5GS() {
 			case nasMessage.RegistrationType5GSInitialRegistration:
 				if err := HandleInitialRegistration(ctx, amfUe, accessType); err != nil {
 					logger.GmmLog.Errorln(err)


### PR DESCRIPTION
## Summary

Follow-up to #735 (@gab-arrobo's request there): route the **remaining direct reads** of the `AmfUe` identity fields — `Supi`, `Pei`, `Gpsi`, `Guti`, `Tmsi`, `RegistrationType5GS` — through the `Get*` accessors that #735 introduced, so all identity access outside the `context` package goes through the `identityMu`-synchronized API.

## Dependency — stacked on #735

This **depends on #735**, which adds the `Get*`/`Set*`/`IdentitySnapshot` accessors consumed here. Please merge #735 first; until then its commits appear in this PR's diff and will drop out once #735 lands (I'll rebase if needed). #735 already converted every identity **write** (→ `Set*`) and every **cross-goroutine read** (→ `Get*`/`IdentitySnapshot`); this PR finishes the remaining same-goroutine reads.

## Scope

69 reads converted across `consumer/` (`am_policy`, `communication`, `sm_context`, `subscriber_data_management`, `ue_context_management`) and `gmm/` (`handler`, `message/build`, `sm`).

**No behavioural change.** These reads execute on the UE's own NAS-processing goroutine, serialized with the writers, so they were already race-free — routing them through `Get*` makes the access pattern uniform and stops a future cross-goroutine reader from silently reintroducing a race.

**Left as direct access — the `context` package itself.** It owns `AmfUe` and defines the accessors, so internal direct field access is idiomatic, and #735 already routed its cross-goroutine reads through `Get*`. (Standard encapsulation: accessors are for external callers.) Happy to convert those too if you'd prefer.

## Verification

`go build ./...` + `go vet ./...` clean and `golangci-lint v2.11.3` (`.golangci.yml`) → **0 issues**, in the `linux/amd64` container. The change is purely `field` → `GetField()`; the compiler confirms every converted receiver is an `*AmfUe`.
