### PR TITLE
ngap: publish UE context on handover completion

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -3192,6 +3192,7 @@ func HandleHandoverNotify(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 		}
 		amfUe.AttachRanUe(targetUe)
 		context.StoreContextInDB(amfUe)
+		amfUe.PublishUeCtxtInfo()
 		ngap_message.SendUEContextReleaseCommand(sourceUe, context.UeContextReleaseHandover, ngapType.CausePresentRadioNetwork,
 			ngapType.CauseRadioNetworkPresentSuccessfulHandover)
 	}
@@ -3400,6 +3401,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 			return
 		}
 		context.StoreContextInDB(amfUe)
+		amfUe.PublishUeCtxtInfo()
 		ngap_message.SendPathSwitchRequestAcknowledge(ranUe, pduSessionResourceSwitchedList,
 			pduSessionResourceReleasedListPSAck, false, nil, nil, nil)
 	} else if len(pduSessionResourceReleasedListPSFail.List) > 0 {


### PR DESCRIPTION
## Problem

The AMF publishes a UE-context event on every registration lifecycle transition
(Authentication, SecurityMode, Registered, Deregistered) via
`AmfUe.PublishUeCtxtInfo()`, but not at handover completion.
`HandleHandoverNotify` (N2) and `HandlePathSwitchRequest` (Xn) re-point the UE at
the target gNB without publishing, so a UE's cell change is invisible on the
metric stream until its next unrelated event. Real-time handover / serving-cell
tracking is therefore not possible for consumers of the stream.

## Change

Publish the UE context at both handover-completion points, once the context
already points at the target gNB (after `AttachRanUe` / `SwitchToRan` and the
existing `StoreContextInDB`). Each publish is tagged on the `coreMsgType` marker
with the handover type (`amf_handover_n2` / `amf_handover_xn`), so consumers get
the new serving `GnbId`/`TacId` and the handover type directly rather than
inferring it.

`PublishUeCtxtEvent` gains a `PublishUeCtxtEventWithMsg` variant that carries the
marker; the existing signature is preserved and delegates to it, so there is no
behavior change for existing callers — the marker is only set when a handover
type is supplied.

## Notes

- The `coreMsgType` field is otherwise set by the SMF path; it is populated here
  only when a handover type is supplied, so existing subscriber-event consumers
  that ignore it are unaffected.

## Testing

Verified on a live SD-Core deployment (rel-3.1.1 AMF): both N2 and Xn handovers
now emit a target-gNB context event tagged with the correct handover type and
carrying the new serving gNB. Before this change, neither handover produced any
event on the stream.
