### PR TITLE
Relay the SMF's PDU session rejection to the UE

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -252,8 +252,10 @@ func SendCreateSmContextRequest(ctx context.Context, ue *amf_context.AmfUe, smCo
 		}
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503, 504:
-			if errResponse, ok := openapi.ErrorModel[models.PostSmContexts400Response](err); ok {
-				errorResponse = &errResponse
+			if errResponse, ok := decodeErrorResponseBody[models.PostSmContexts400Response](httpResponse); ok {
+				errorResponse = errResponse
+			} else if errModel, ok := openapi.ErrorModel[models.PostSmContexts400Response](err); ok {
+				errorResponse = &errModel
 			} else {
 				err1 = err
 			}
@@ -633,8 +635,10 @@ func SendUpdateSmContextRequest(ctx context.Context, smContext *amf_context.SmCo
 		}
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503:
-			if errResponse, ok := openapi.ErrorModel[models.UpdateSmContext400Response](err); ok {
-				errorResponse = &errResponse
+			if errResponse, ok := decodeErrorResponseBody[models.UpdateSmContext400Response](httpResponse); ok {
+				errorResponse = errResponse
+			} else if errModel, ok := openapi.ErrorModel[models.UpdateSmContext400Response](err); ok {
+				errorResponse = &errModel
 			} else {
 				err1 = err
 			}
@@ -649,6 +653,53 @@ func SendUpdateSmContextRequest(ctx context.Context, smContext *amf_context.SmCo
 		err1 = err
 	}
 	return response, errorResponse, problemDetail, err1
+}
+
+// decodeErrorResponseBody decodes an error response body into T, reporting whether it
+// succeeded.
+//
+// openapi.ErrorModel cannot return the multipart wrapper types. The generated client decodes a
+// 4xx body into the JSON-only error model - models.SmContextCreateError for PostSmContexts,
+// models.SmContextUpdateError for UpdateSmContext - and stores that in
+// GenericOpenAPIError.RawModel, so asserting to models.PostSmContexts400Response or
+// models.UpdateSmContext400Response never succeeds. Those wrappers are also the only models
+// carrying binaryDataN1SmMessage, which is the NAS reject the UE has to be given: the JSON-only
+// models hold n1SmMsg as a RefToBinaryData reference, not the bytes.
+//
+// The generated client leaves the body readable, so it is decoded here the same way the success
+// path does. This mirrors decodeSuccessResponseBody rather than sharing its body deliberately,
+// so that a fix for the error path cannot regress the success path.
+//
+// A decode that produced no jsonData counts as a failure. Every field on the wrappers is
+// omitempty and neither validates on unmarshal, so any JSON object decodes into an empty
+// wrapper - including the application/problem+json body TS 29.502 specifies for an error that
+// carries no N1 message. Reporting success there would hand the caller a wrapper with nothing
+// in it and a nil error, hiding the SMF's cause behind an unreadable N1 message; reporting
+// failure leaves that body to openapi.ErrorModel, which is what handles it today.
+func decodeErrorResponseBody[T any](httpResponse *http.Response) (*T, bool) {
+	if httpResponse == nil || httpResponse.Body == nil {
+		return nil, false
+	}
+	body, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return nil, false
+	}
+	if err = httpResponse.Body.Close(); err != nil {
+		return nil, false
+	}
+	httpResponse.Body = io.NopCloser(bytes.NewBuffer(body))
+	if len(body) == 0 {
+		return nil, false
+	}
+	var target T
+	if err = openapi.Decode(&target, body, httpResponse.Header.Get("Content-Type")); err != nil {
+		return nil, false
+	}
+	wrapper, ok := any(&target).(interface{ HasJsonData() bool })
+	if !ok || !wrapper.HasJsonData() {
+		return nil, false
+	}
+	return &target, true
 }
 
 func decodeSuccessResponseBody(httpResponse *http.Response, target any) error {

--- a/consumer/sm_context_test.go
+++ b/consumer/sm_context_test.go
@@ -503,3 +503,301 @@ func readMultipartRequestPartsByName(t *testing.T, r *http.Request, expectedPart
 
 	return parts, mediaType
 }
+
+// writeMultipartRejection responds the way the SMF does when it refuses a PDU session: a
+// multipart body carrying the problem details in jsonData and the GSM reject in
+// binaryDataN1SmMessage.
+func writeMultipartRejection(t *testing.T, w http.ResponseWriter, status int, jsonData any, nas []byte) {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	encoded, err := json.Marshal(jsonData)
+	if err != nil {
+		t.Fatalf("failed to marshal jsonData: %v", err)
+	}
+	jsonPart, err := writer.CreateFormField("jsonData")
+	if err != nil {
+		t.Fatalf("failed to create jsonData part: %v", err)
+	}
+	if _, err = jsonPart.Write(encoded); err != nil {
+		t.Fatalf("failed to write jsonData part: %v", err)
+	}
+	nasPart, err := writer.CreateFormFile("binaryDataN1SmMessage", "n1SmMsg")
+	if err != nil {
+		t.Fatalf("failed to create binaryDataN1SmMessage part: %v", err)
+	}
+	if _, err = nasPart.Write(nas); err != nil {
+		t.Fatalf("failed to write binaryDataN1SmMessage part: %v", err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(status)
+	if _, err = w.Write(body.Bytes()); err != nil {
+		t.Fatalf("failed to write response body: %v", err)
+	}
+}
+
+// TestSendCreateSmContextRequestRelaysSmfRejection covers the whole point of the error path:
+// when the SMF refuses a session it attaches the NAS reject the UE has to receive, and the AMF
+// has to hand that back so gmm can relay it.
+//
+// The assertions on err and errorResponse are what make the relay reachable. gmm/handler.go
+// checks err before errResp and returns on a non-nil error, so returning an error here - which
+// is what happens when the response body is not decoded - leaves the relay branch dead and the
+// UE waiting for T3580.
+func TestSendCreateSmContextRequestRelaysSmfRejection(t *testing.T) {
+	// PDU SESSION ESTABLISHMENT REJECT with 5GSM cause #70, missing or unknown DNN in a slice.
+	rejectNas := []byte{0x2e, 0x0a, 0xc1, 0x46}
+
+	self := amfContext.AMF_Self()
+	originalNfID := self.NfId
+	originalServedGuamiList := append([]models.Guami(nil), self.ServedGuamiList...)
+	originalUriScheme := self.UriScheme
+	originalRegisterIPv4 := self.RegisterIPv4
+	originalSBIPort := self.SBIPort
+	defer func() {
+		self.NfId = originalNfID
+		self.ServedGuamiList = originalServedGuamiList
+		self.UriScheme = originalUriScheme
+		self.RegisterIPv4 = originalRegisterIPv4
+		self.SBIPort = originalSBIPort
+	}()
+
+	self.NfId = "amf-instance-id"
+	self.ServedGuamiList = []models.Guami{{
+		PlmnId: models.PlmnIdNid{Mcc: "001", Mnc: "01"},
+		AmfId:  "cafe00",
+	}}
+	self.UriScheme = models.URISCHEME_HTTP
+	self.RegisterIPv4 = "127.0.0.1"
+	self.SBIPort = 29518
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		readMultipartRequestPartsByName(t, r, []string{"jsonData", "binaryDataN1SmMessage"})
+
+		// Title and Detail are populated on purpose. They sit nested under error, so
+		// FormatErrorMessage still finds no top-level Title and the consumer's
+		// `httpResponse.Status != err.Error()` guard does not trip.
+		writeMultipartRejection(t, w, http.StatusForbidden, models.SmContextCreateError{
+			Error: models.ExtProblemDetails{
+				Title:  openapi.PtrString("DNN_DENIED"),
+				Detail: openapi.PtrString("DNN not configured for the requested slice"),
+			},
+			N1SmMsg: &models.RefToBinaryData{ContentId: "n1SmMsg"},
+		}, rejectNas)
+	}))
+	defer server.Close()
+
+	ue := &amfContext.AmfUe{
+		ServingAMF: self,
+		Supi:       "imsi-001010000000001",
+		Tai: models.Tai{
+			PlmnId: models.PlmnId{Mcc: "001", Mnc: "01"},
+			Tac:    "000001",
+		},
+		Guti:     "00101cafe00000001",
+		TimeZone: "+00:00",
+	}
+
+	smContext := amfContext.NewSmContext(10)
+	smContext.SetSmfUri(server.URL)
+	smContext.SetSmfID("smf-test")
+	smContext.SetSnssai(models.Snssai{Sst: 1, Sd: openapi.PtrString("010203")})
+	smContext.SetDnn("internet")
+	smContext.SetAccessType(models.ACCESSTYPE__3_GPP_ACCESS)
+
+	_, _, errorResponse, problemDetail, err := SendCreateSmContextRequest(
+		context.Background(),
+		ue,
+		smContext,
+		models.REQUESTTYPE_INITIAL_REQUEST.Ptr(),
+		[]byte{0x7e, 0x00, 0x68, 0x01},
+	)
+	if err != nil {
+		t.Fatalf("expected no error so that gmm reaches its relay branch, got %v", err)
+	}
+	if problemDetail != nil {
+		t.Fatalf("expected no problem detail, got %+v", problemDetail)
+	}
+	if errorResponse == nil {
+		t.Fatal("expected the SMF rejection to be returned as errorResponse")
+	}
+	if errorResponse.JsonData == nil {
+		t.Fatal("expected the rejection jsonData to be decoded")
+	}
+	if title := errorResponse.JsonData.Error.GetTitle(); title != "DNN_DENIED" {
+		t.Errorf("expected rejection title %q, got %q", "DNN_DENIED", title)
+	}
+
+	nasFile := errorResponse.GetBinaryDataN1SmMessage()
+	if nasFile == nil {
+		t.Fatal("expected the NAS reject to be carried in binaryDataN1SmMessage")
+	}
+	got, err := io.ReadAll(nasFile)
+	if err != nil {
+		t.Fatalf("failed to read the NAS reject: %v", err)
+	}
+	if !bytes.Equal(got, rejectNas) {
+		t.Errorf("expected NAS reject %v, got %v", rejectNas, got)
+	}
+}
+
+// TestSendUpdateSmContextRequestRelaysSmfRejection covers the same shape on the modification
+// path, which asks for models.UpdateSmContext400Response while the generated client stores
+// models.SmContextUpdateError.
+func TestSendUpdateSmContextRequestRelaysSmfRejection(t *testing.T) {
+	rejectNas := []byte{0x2e, 0x0a, 0xd1, 0x1f}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		readMultipartRequestPartsByName(t, r, []string{"jsonData", "binaryDataN1SmMessage"})
+		writeMultipartRejection(t, w, http.StatusForbidden, models.SmContextUpdateError{
+			Error:   models.ExtProblemDetails{Title: openapi.PtrString("MODIFICATION_REJECTED")},
+			N1SmMsg: &models.RefToBinaryData{ContentId: "n1SmMsg"},
+		}, rejectNas)
+	}))
+	defer server.Close()
+
+	smContext := amfContext.NewSmContext(10)
+	smContext.SetSmfUri(server.URL)
+	smContext.SetSmContextRef("ctx-ref")
+
+	_, errorResponse, problemDetail, err := SendUpdateSmContextRequest(
+		context.Background(),
+		smContext,
+		models.SmContextUpdateData{},
+		[]byte{0x7e, 0x00, 0x69, 0x01},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error so that the caller can relay the rejection, got %v", err)
+	}
+	if problemDetail != nil {
+		t.Fatalf("expected no problem detail, got %+v", problemDetail)
+	}
+	if errorResponse == nil {
+		t.Fatal("expected the SMF rejection to be returned as errorResponse")
+	}
+	nasFile := errorResponse.GetBinaryDataN1SmMessage()
+	if nasFile == nil {
+		t.Fatal("expected the NAS reject to be carried in binaryDataN1SmMessage")
+	}
+	got, err := io.ReadAll(nasFile)
+	if err != nil {
+		t.Fatalf("failed to read the NAS reject: %v", err)
+	}
+	if !bytes.Equal(got, rejectNas) {
+		t.Errorf("expected NAS reject %v, got %v", rejectNas, got)
+	}
+}
+
+// TestSendUpdateSmContextRequestRejectsHollowErrorBody covers the fallback the decode has to
+// leave intact. Every field on models.UpdateSmContext400Response is omitempty and the model does
+// not validate on unmarshal, so any JSON object decodes into it without error - including the
+// application/problem+json body TS 29.502 specifies for an error carrying no N1 message. Taking
+// that as a successful decode would return a wrapper with nothing in it alongside a nil error,
+// which reads to the caller as a relayable rejection: gmm would log "could not read N1 SM
+// message" instead of the SMF's cause, and producer/callback.go would send the UE a DL NAS
+// Transport with an empty payload container.
+func TestSendUpdateSmContextRequestRejectsHollowErrorBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+	}{
+		{
+			name:        "SmContextUpdateError as problem+json",
+			contentType: "application/problem+json",
+			body:        `{"error":{"title":"N1SmError","status":403,"cause":"N1_SM_ERROR"}}`,
+		},
+		{
+			name:        "bare problem details",
+			contentType: "application/problem+json",
+			body:        `{"title":"Not Found","status":404,"cause":"CONTEXT_NOT_FOUND"}`,
+		},
+		{
+			name:        "null body",
+			contentType: "application/json",
+			body:        `null`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(http.StatusForbidden)
+				if _, err := w.Write([]byte(tc.body)); err != nil {
+					t.Errorf("failed to write response body: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			smContext := amfContext.NewSmContext(10)
+			smContext.SetSmfUri(server.URL)
+			smContext.SetSmContextRef("ctx-ref")
+
+			_, errorResponse, problemDetail, err := SendUpdateSmContextRequest(
+				context.Background(),
+				smContext,
+				models.SmContextUpdateData{},
+				[]byte{0x7e, 0x00, 0x69, 0x01},
+				nil,
+			)
+			if errorResponse != nil {
+				t.Errorf("expected no errorResponse for a body carrying no jsonData, got %+v", errorResponse)
+			}
+			if problemDetail != nil {
+				t.Errorf("expected no problem detail, got %+v", problemDetail)
+			}
+			if err == nil {
+				t.Error("expected the rejection to be reported as an error so the cause reaches the log")
+			}
+		})
+	}
+}
+
+// TestSendUpdateSmContextRequestDecodesJsonRejection covers the other side of that guard: an
+// error body that does carry jsonData still decodes, even when it is not multipart because the
+// SMF had no N1 message to attach.
+func TestSendUpdateSmContextRequestDecodesJsonRejection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		if _, err := w.Write([]byte(`{"jsonData":{"error":{"cause":"N1_SM_ERROR"}}}`)); err != nil {
+			t.Errorf("failed to write response body: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	smContext := amfContext.NewSmContext(10)
+	smContext.SetSmfUri(server.URL)
+	smContext.SetSmContextRef("ctx-ref")
+
+	_, errorResponse, problemDetail, err := SendUpdateSmContextRequest(
+		context.Background(),
+		smContext,
+		models.SmContextUpdateData{},
+		[]byte{0x7e, 0x00, 0x69, 0x01},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if problemDetail != nil {
+		t.Fatalf("expected no problem detail, got %+v", problemDetail)
+	}
+	if errorResponse == nil {
+		t.Fatal("expected the SMF rejection to be returned as errorResponse")
+	}
+	if errorResponse.JsonData == nil {
+		t.Fatal("expected the rejection jsonData to be decoded")
+	}
+	if cause := errorResponse.JsonData.Error.GetCause(); cause != "N1_SM_ERROR" {
+		t.Errorf("expected rejection cause %q, got %q", "N1_SM_ERROR", cause)
+	}
+}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -238,10 +238,17 @@ func transport5GSMMessage(
 		}
 		if errResp != nil {
 			ue.GmmLog.Warnf("pdu session establishment request is rejected by SMF[pduSessionId:%d]", pduID)
-			binaryDataN1SmMessage, err := io.ReadAll(errResp.GetBinaryDataN1SmMessage())
+			binaryDataN1SmMessage, err := readBinaryResponseFile(errResp.GetBinaryDataN1SmMessage())
 			if err != nil {
 				ue.GmmLog.Errorf("could not read N1 SM message: %v", err)
 				return fmt.Errorf("could not read N1 SM message: %w", err)
+			}
+			// The SMF can refuse without attaching a reject, in which case its response
+			// carries jsonData alone. There is nothing to relay then, and an empty
+			// payload container is not a message the UE can act on.
+			if len(binaryDataN1SmMessage) == 0 {
+				ue.GmmLog.Warnf("SMF rejection carries no N1 SM message[pduSessionId:%d]", pduID)
+				return nil
 			}
 			sendDLNASTransport(ue.GetRanUe(anType), anType, nasMessage.PayloadContainerTypeN1SMInfo,
 				binaryDataN1SmMessage, pduID, 0, nil, 0)
@@ -455,14 +462,14 @@ func forward5GSMMessageToSMF(
 		return nil
 	} else if errResponse != nil {
 		errJSON := errResponse.GetJsonData()
-		n1Msg, err := io.ReadAll(errResponse.GetBinaryDataN1SmMessage())
+		n1Msg, err := readBinaryResponseFile(errResponse.GetBinaryDataN1SmMessage())
 		if err != nil {
 			ue.GmmLog.Errorf("could not read N1 SM message: %v", err)
 			return fmt.Errorf("could not read N1 SM message: %w", err)
 		}
 		ue.GmmLog.Warnf("PDU Session Modification Procedure is rejected by SMF[pduSessionId:%d], Error[%s]",
 			pduSessionID, errJSON.Error.GetCause())
-		if n1Msg != nil {
+		if len(n1Msg) > 0 {
 			sendDLNASTransport(ue.GetRanUe(accessType), accessType, nasMessage.PayloadContainerTypeN1SMInfo,
 				n1Msg, pduSessionID, 0, nil, 0)
 		}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -169,12 +169,22 @@ func SmContextStatusNotifyProcedure(ctx ctxt.Context, guti string, pduSessionID 
 					// TODO: handle response(response N2SmInfo to RAN if exists)
 				} else if errResponse != nil {
 					ue.ProducerLog.Warnf("PDU Session Establishment Request is rejected by SMF[pduSessionId:%d]", pduSessionID)
-					binaryDataN1SmMessage, err1 := io.ReadAll(errResponse.GetBinaryDataN1SmMessage())
-					if err1 != nil {
-						ue.ProducerLog.Errorf("read binaryDataN1SmMessage failed: %+v", err1)
+					var binaryDataN1SmMessage []byte
+					if n1File := errResponse.GetBinaryDataN1SmMessage(); n1File != nil {
+						if data, readErr := io.ReadAll(n1File); readErr != nil {
+							ue.ProducerLog.Errorf("read binaryDataN1SmMessage failed: %+v", readErr)
+						} else {
+							binaryDataN1SmMessage = data
+						}
 					}
-					gmm_message.SendDLNASTransport(ue.RanUe[anType], anType,
-						nasMessage.PayloadContainerTypeN1SMInfo, binaryDataN1SmMessage, pduSessionID, 0, nil, 0)
+					// The SMF can refuse without attaching a reject, and an empty payload
+					// container is not a message the UE can act on.
+					if len(binaryDataN1SmMessage) == 0 {
+						ue.ProducerLog.Warnf("SMF rejection carries no N1 SM message[pduSessionId:%d]", pduSessionID)
+					} else {
+						gmm_message.SendDLNASTransport(ue.RanUe[anType], anType,
+							nasMessage.PayloadContainerTypeN1SMInfo, binaryDataN1SmMessage, pduSessionID, 0, nil, 0)
+					}
 				} else if err != nil {
 					ue.ProducerLog.Errorf("failed to create smContext[pduSessionID: %d], Error[%s]", pduSessionID, err.Error())
 				} else {


### PR DESCRIPTION
## The symptom

When the SMF refuses a PDU session it attaches the NAS reject for the UE to its 403 response.
The AMF discards it, so the UE is told nothing and retransmits until T3580 expires. Observed
against an unserved DNN:

```
SMF:  16 x "not matched DNN"                  -> refused, N1 SM message attached
AMF:   0 x "rejected by SMF"                  -> the relay branch never ran
AMF:  ERROR gmm/handler.go  createSmContextRequest Error: 403 Forbidden
UE:   [nas] Retransmitting PDU Session Establishment Request due to T3580 expiry
```

This affects every refusal reason the SMF has — unserved DNN, missing subscription, UDM or PCF
discovery failure, IP allocation failure, user-plane failure — not just the DNN one used to
reproduce it.

## Why the relay never runs

`gmm/handler.go` already contains the correct relay code, and it is reachable. The rejection
never gets that far, because `openapi.ErrorModel` cannot return the type the consumer asks it
for.

The generated client *does* decode the body, content-type aware, so multipart is handled — but
it decodes into the **JSON-only** error model and stores that in
`GenericOpenAPIError.RawModel`:

| Operation | client stores in `RawModel` | consumer asserts |
|---|---|---|
| `PostSmContexts` | `models.SmContextCreateError` | `models.PostSmContexts400Response` |
| `UpdateSmContext` | `models.SmContextUpdateError` | `models.UpdateSmContext400Response` |

The assertion always fails, `err1` is set, and `gmm` returns on the error before reaching its
`errResp` branch.

## Why correcting the asserted type is not enough

The JSON-only models carry `n1SmMsg` as a `RefToBinaryData` **reference**. Only the multipart
wrappers have `BinaryDataN1SmMessage`, and that is the reject the UE has to receive. So
asserting to `SmContextCreateError` would succeed and still leave the relay with nothing to
send.

The body is therefore decoded again here, into the wrapper. That is possible because the
generated client leaves the body readable (`Body = io.NopCloser(bytes.NewBuffer(...))`), which
is the same property the existing success path already relies on.

## Notes on the shape of the fix

- `decodeErrorResponseBody` **mirrors** `decodeSuccessResponseBody` rather than sharing its
  body, so a fix for the error path cannot regress the success path.
- It reports failure on an empty body, so an empty 4xx does not yield an `errorResponse` with
  nothing in it — and on a decode that produced no `jsonData`, for the reason below.
- No **reordering** of `gmm/handler.go` was required. Its order is already correct: `err1` is
  only assigned when the decode fails, so once `errorResponse` is populated the function returns
  a nil error and the existing branch runs. Reordering it would also mask genuine transport
  failures. The relay branches did need guarding, though — see the next section.
- The `ErrorModel` call is kept as a fallback, so behaviour is unchanged if a future generated
  client does store the wrapper type.
- The **modification path** had the identical mismatch and gets the same treatment. The
  **release path** does not need it: it returns `ProblemDetails` and relays no N1 message.

## Why the decode is not tried unconditionally

Every field on `PostSmContexts400Response`/`UpdateSmContext400Response` is `omitempty`, and
neither model validates on unmarshal. So `json.Unmarshal` of **any** JSON object into one
succeeds and yields an all-nil struct. Trying the wrapper decode first therefore reported
success for every JSON error body, `openapi.ErrorModel` was never consulted, and `err` became
nil — handing the caller a wrapper with nothing in it, which reads exactly like a relayable
rejection.

The shape that hit this is the **conformant** one: TS 29.502 specifies bare
`application/problem+json` for an error carrying no N1 message. `decodeErrorResponseBody` now
requires `HasJsonData()`, so those bodies fall back to `openapi.ErrorModel` as they do today.

## Why the relay branches needed a guard

Once the wrapper decodes, the relay branches become reachable for responses they never saw
before — and they assumed an N1 message is present. It need not be: the SMF can refuse with
`jsonData` alone, and `formContextCreateErrRsp` does exactly that. `io.ReadAll` on the resulting
nil `*os.File` returns `invalid argument`, which turned a rejection into a read error in `gmm`
and, in `producer/callback.go` — which logged the failure and then carried on — into a DL NAS
Transport carrying an **empty payload container**.

Both now read through `readBinaryResponseFile`, the helper the success path already uses, and
relay only when there are bytes to relay. This is why the diff touches `gmm/handler.go` and
`producer/callback.go`; happy to split it into a follow-up PR if you would rather keep this one
to the consumer.

## Tests

The two relay tests assert a **nil error** alongside the populated `errorResponse`, because that
is precisely what makes the relay reachable in `gmm`. With the decode removed they fail with
`403 Forbidden` — which is what the AMF logs in production today.

Two more pin the `jsonData` check from both sides: the body shapes that decode into an empty
wrapper have to be reported as errors, and a `jsonData`-bearing body that is *not* multipart has
to decode anyway. Removing the check fails all three subtests of the first.

They populate `Title` and `Detail` on purpose: those sit nested under `error`, so
`FormatErrorMessage` still finds no top-level `Title` and the consumer's
`httpResponse.Status != err.Error()` guard does not trip.

Verified with the repo's own `make test` (Linux, `-race`, 12 packages, 0 failures) plus
`staticcheck ./...` and `golangci-lint run` (v2.11.3), both under `GOOS=linux` since
`SCTPConn.SyscallConn` is Linux-only.

## Related

There is a companion defect in the SMF: the cause it puts in that reject is a 5GMM value in a
5GSM IE (`omec-project/smf#619`). Until this change lands, that one is unobservable, because no
reject reaches the UE at all.

While tracing this I also found that the `httpResponse.Status != err.Error()` guard swallows the
`411, 413, 415, 429` branches entirely, since `ProblemDetails` *does* have top-level
`Title`/`Detail` so the formatted message never equals the bare status. That is a separate
defect and not addressed here — happy to send it separately.

