### PR TITLE
fix: do not treat a modification request as a new PDU session

### DIFF
--- a/gmm/establishment_payload_test.go
+++ b/gmm/establishment_payload_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package gmm
+
+import (
+	ctxt "context"
+	"testing"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/nas/v2"
+	"github.com/omec-project/nas/v2/nasMessage"
+	"github.com/omec-project/nas/v2/nasType"
+	"github.com/omec-project/openapi/v2/models"
+	"go.uber.org/zap"
+)
+
+// gsmPayload encodes a bare 5GSM message of the given type, which is all the
+// Request-type gate inspects.
+func gsmPayload(t *testing.T, msgType uint8) []byte {
+	t.Helper()
+	return []byte{
+		nasMessage.Epd5GSSessionManagementMessage,
+		0x0a, // PDU session identity
+		0x00, // PTI
+		msgType,
+	}
+}
+
+func TestIsEstablishmentRequestFromUE(t *testing.T) {
+	ue := &context.AmfUe{GmmLog: zap.NewNop().Sugar()}
+
+	tests := []struct {
+		name string
+		msg  []byte
+		want bool
+	}{
+		{"establishment request", gsmPayload(t, nas.MsgTypePDUSessionEstablishmentRequest), true},
+		{"modification request", gsmPayload(t, nas.MsgTypePDUSessionModificationRequest), false},
+		{"release request", gsmPayload(t, nas.MsgTypePDUSessionReleaseRequest), false},
+		{"release complete", gsmPayload(t, nas.MsgTypePDUSessionReleaseComplete), false},
+		{"empty payload", nil, false},
+		{"undecodable payload", []byte{0xff}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEstablishmentRequestFromUE(tc.msg, ue); got != tc.want {
+				t.Fatalf("isEstablishmentRequestFromUE(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// A modification request carrying Request type "initial request" must not be mistaken
+// for an establishment. Both the SM context delete and the duplicate-session release are
+// gated on this discriminator, so a false here is what keeps an established session
+// intact when a UE signals the wrong Request type.
+func TestModificationRequestIsNotTreatedAsEstablishment(t *testing.T) {
+	ue := &context.AmfUe{GmmLog: zap.NewNop().Sugar()}
+	modReq := gsmPayload(t, nas.MsgTypePDUSessionModificationRequest)
+
+	if isEstablishmentRequestFromUE(modReq, ue) {
+		t.Fatal("a PDU session modification request must not be classified as an establishment request")
+	}
+}
+
+// The discriminator is only useful if both gates consult it. This pins the observable
+// consequence: an established session survives a modification request that carries the
+// wrong Request type. The forwarding that follows is expected to fail in a unit test —
+// there is no SMF — and the assertion is deliberately on the SM context, not the error.
+func TestModificationRequestWithInitialRequestTypeKeepsSmContext(t *testing.T) {
+	const pduID int32 = 10
+
+	ue := &context.AmfUe{
+		GmmLog: zap.NewNop().Sugar(),
+		NASLog: zap.NewNop().Sugar(),
+	}
+	ue.SmContextList.Store(pduID, context.NewSmContext(pduID))
+
+	ul := nasMessage.NewULNASTransport(0)
+	ul.PduSessionID2Value = nasType.NewPduSessionID2Value(nasMessage.ULNASTransportPduSessionID2ValueType)
+	ul.SetPduSessionID2Value(uint8(pduID))
+	ul.RequestType = nasType.NewRequestType(nasMessage.ULNASTransportRequestTypeType)
+	ul.SetRequestTypeValue(nasMessage.ULNASTransportRequestTypeInitialRequest)
+	ul.SetPayloadContainerContents(gsmPayload(t, nas.MsgTypePDUSessionModificationRequest))
+
+	// Forwarding cannot succeed without an SMF; the error is expected and is not what
+	// this test asserts on.
+	if err := transport5GSMMessage(ctxt.Background(), ue, models.ACCESSTYPE__3_GPP_ACCESS, ul); err != nil {
+		t.Logf("forwarding failed as expected with no SMF reachable: %v", err)
+	}
+
+	if _, ok := ue.SmContextFindByPDUSessionID(pduID); !ok {
+		t.Fatal("SM context was discarded for a modification request carrying Request type " +
+			"\"initial request\"; the established session must survive it")
+	}
+}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -182,6 +182,12 @@ func transport5GSMMessage(
 				// Request type says "initial request" but the payload is not an establishment
 				// request. Forward it and let the SMF answer; releasing the session here would
 				// punish the subscriber for the UE's malformed signalling.
+				//
+				// This condition is always true as the code stands: an establishment request on an
+				// existing session is consumed by the delete above, which clears `has` and so skips
+				// this switch entirely. It is written as a condition rather than dropped because
+				// what follows it tears down a working session, and that call should depend on the
+				// payload check explicitly rather than on the reachability of a block above it.
 				ue.GmmLog.Warnf("request type is initial request but payload is not a PDU session establishment request (pdu session id: %d); forwarding to SMF", pduID)
 				return forward5GSMMessageToSMF(ctx, ue, anType, pduID, smCtx, smMsg)
 			}
@@ -365,6 +371,9 @@ func isEstablishmentRequestFromUE(smMsg []byte, ue *context.AmfUe) bool {
 		ue.GmmLog.Errorf("could not decode Nas message: %v", err)
 		return false
 	}
+	// The order of these two operands is load-bearing. nas.Message embeds *GsmMessage, which
+	// embeds GsmHeader by value, so msg.GsmHeader dereferences the pointer — reading it when
+	// GsmMessage is nil panics. The short circuit is the nil check.
 	return msg.GsmMessage != nil &&
 		msg.GsmHeader.GetMessageType() == nas.MsgTypePDUSessionEstablishmentRequest
 }

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -150,7 +150,14 @@ func transport5GSMMessage(
 		return nil
 	}
 
-	if has && isInitialRequest(requestType) {
+	// A Request type of "initial request" only means "establish a new session" when the
+	// payload actually is one. Per TS 24.501 subclause 5.4.5.2.2 the Request type IE is carried
+	// on a PDU SESSION MODIFICATION REQUEST as well, so a UE that sets "initial request" there
+	// would otherwise have its established session discarded here and released below.
+	// Decoded only for an initial request: this is the uplink NAS transport hot path.
+	isEstablishment := isInitialRequest(requestType) && isEstablishmentRequestFromUE(smMsg, ue)
+
+	if has && isEstablishment {
 		ue.SmContextList.Delete(pduID)
 		has, smCtx = false, nil
 	}
@@ -166,6 +173,13 @@ func transport5GSMMessage(
 
 		switch requestType.GetRequestTypeValue() {
 		case nasMessage.ULNASTransportRequestTypeInitialRequest:
+			if !isEstablishment {
+				// Request type says "initial request" but the payload is not an establishment
+				// request. Forward it and let the SMF answer; releasing the session here would
+				// punish the subscriber for the UE's malformed signalling.
+				ue.GmmLog.Warnf("request type is initial request but payload is not a PDU session establishment request (pdu session id: %d); forwarding to SMF", pduID)
+				return forward5GSMMessageToSMF(ctx, ue, anType, pduID, smCtx, smMsg)
+			}
 			return releaseDuplicatePDUSession(ctx, ue, anType, pduID, smCtx, smMsg, ulNasTransport)
 
 		case nasMessage.ULNASTransportRequestTypeExistingPduSession:
@@ -331,6 +345,23 @@ func is5GSMStatusFromUE(smMsg []byte, ue *context.AmfUe) bool {
 		return true
 	}
 	return false
+}
+
+// isEstablishmentRequestFromUE reports whether the N1 SM payload is a PDU SESSION
+// ESTABLISHMENT REQUEST. The Request type IE alone cannot answer that: it is carried on a
+// PDU SESSION MODIFICATION REQUEST too, and only the payload says which procedure the UE
+// is running.
+func isEstablishmentRequestFromUE(smMsg []byte, ue *context.AmfUe) bool {
+	if len(smMsg) == 0 {
+		return false
+	}
+	msg := new(nas.Message)
+	if err := msg.PlainNasDecode(&smMsg); err != nil {
+		ue.GmmLog.Errorf("could not decode Nas message: %v", err)
+		return false
+	}
+	return msg.GsmMessage != nil &&
+		msg.GsmHeader.GetMessageType() == nas.MsgTypePDUSessionEstablishmentRequest
 }
 
 func sendNotForwarded(ue *context.AmfUe, anType models.AccessType, smMsg []byte, pduID int32) error {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -154,10 +154,15 @@ func transport5GSMMessage(
 	// payload actually is one. Per TS 24.501 subclause 5.4.5.2.2 the Request type IE is carried
 	// on a PDU SESSION MODIFICATION REQUEST as well, so a UE that sets "initial request" there
 	// would otherwise have its established session discarded here and released below.
-	// Decoded only for an initial request: this is the uplink NAS transport hot path.
-	isEstablishment := isInitialRequest(requestType) && isEstablishmentRequestFromUE(smMsg, ue)
+	//
+	// Guarded on `has` as well as on the Request type, and in that order: only a request against
+	// a session that already exists can be misclassified, and both readers below are reached only
+	// when one does. A genuine first establishment is the common case on this hot path and must
+	// not pay for a decode whose answer it never consults.
+	establishmentOnExistingSession := has && isInitialRequest(requestType) &&
+		isEstablishmentRequestFromUE(smMsg, ue)
 
-	if has && isEstablishment {
+	if establishmentOnExistingSession {
 		ue.SmContextList.Delete(pduID)
 		has, smCtx = false, nil
 	}
@@ -173,7 +178,7 @@ func transport5GSMMessage(
 
 		switch requestType.GetRequestTypeValue() {
 		case nasMessage.ULNASTransportRequestTypeInitialRequest:
-			if !isEstablishment {
+			if !establishmentOnExistingSession {
 				// Request type says "initial request" but the payload is not an establishment
 				// request. Forward it and let the SMF answer; releasing the session here would
 				// punish the subscriber for the UE's malformed signalling.


### PR DESCRIPTION
## Problem

`transport5GSMMessage` decides that an uplink NAS transport is establishing a new PDU session from the Request type IE alone:

```go
if has && isInitialRequest(requestType) {
    ue.SmContextList.Delete(pduID)
    has, smCtx = false, nil
}
```

TS 24.501 subclause 5.4.5.2.2 says that IE is carried on a **PDU SESSION MODIFICATION REQUEST** as well as on an establishment request:

> The request type is not provided along 5GSM messages other than the PDU SESSION ESTABLISHMENT REQUEST message and the PDU SESSION MODIFICATION REQUEST message.

So a UE that sets "initial request" on a modification has its established session discarded from `SmContextList` before anything inspects the payload. The AMF then falls through to the establishment path and offers the modification request to `CreateSmContext`, which rejects it on the message type.

**Measured on a cluster, and it is worse than the AMF's own behaviour suggests.** This section previously said the session survives at the SMF while the AMF forgets it, leaving a state divergence. It does not survive. `CreateSmContext` purges an existing context for the same PDU session ID *before* it looks at the message type, so the SMF releases the working session and sends a PFCP Session Delete to the UPF, and only then fails to decode the payload and answers 403:

```
smf  producer/pdu_session.go:106  PDUSessionSMContextCreate, old context exist, purging
smf  message/send.go:413          sent PFCP Session Delete Request to NodeID[...]
smf  producer/pdu_session.go:153  PDUSessionSMContextCreate, GsmMessageDecode Error
smf  logger/logger.go:91          | 403 | POST /nsmf-pdusession/v1/sm-contexts
amf  gmm/handler.go:234           createSmContextRequest Error: 403 Forbidden
```

The UE is told nothing and its procedure times out. So the outcome is **total session loss** — control plane, user plane and UPF forwarding state — not a divergence. The AMF's own behaviour is exactly as analysed above; the damage is done by what it provokes the SMF into doing, which is why reasoning about this element alone gave the wrong answer.

A conformant UE sets Request type "modification request" and is unaffected. For a UE that does not — UERANSIM sets "initial request" on a modification, at `src/ue/nas/sm/transport.cpp:71` — this is the difference between a refused modification and a dropped session.

## Fix

Both decision points are gated on the payload actually being an establishment request.

Gating only the `SmContextList` delete would have been **worse than the defect**: it leaves `has` true, which routes the request into the duplicate-session branch, and `releaseDuplicatePDUSession` sends the SMF a release with cause `REL_DUE_TO_DUPLICATE_SESSION_ID` — an active teardown of a working session rather than a local divergence.

That branch was already unreachable before this change, shadowed by the delete above it, and it stays unreachable. It is pre-existing dead code and is left alone rather than removed, to keep this change to one concern.

The payload is decoded only when a session already exists **and** the Request type is "initial request", in that order. Only a request against an existing session can be misclassified, and both readers are reached only when one does — so a genuine first establishment, which is the common case on this hot path, does not pay for a decode whose answer it never consults.

## One behaviour change beyond the headline

A 5GSM STATUS carrying Request type "initial request" was previously swallowed: the discard created the `!has` state that the status check then returned `nil` on. It is now forwarded to the SMF with the context intact. Such a message is non-conformant in the same way — 5.4.5.2.2 provides the IE only with establishment and modification requests — and forwarding is the benign reading.

## Verified against a live core

Run on a single-node SD-Core deployment with a simulator whose Request type IE is configurable, one variable per run.

Against the **unpatched** AMF:

| Request type | outcome |
|---|---|
| 1 "initial request" | AMF deletes its SM context and calls `CreateSMContext`; SMF purges the session and deletes the PFCP session at the UPF, answers 403; UE gets nothing and times out |
| 5 "modification request" | forwarded unchanged; UE gets a MODIFICATION REJECT at +237 ms |
| IE absent | forwarded unchanged; MODIFICATION REJECT at +233 ms |

Against the **patched** AMF, all three values were re-run rather than just the failing one, because "the conformant cases are unaffected" is worth measuring rather than asserting:

| Request type | gate fires | SMF purge at | outcome |
|---|---|---|---|
| 1 "initial request" | **yes**, once | establishment only | MODIFICATION REJECT at +237 ms |
| 5 "modification request" | no | establishment only | MODIFICATION REJECT at +237 ms |
| IE absent | no | establishment only | MODIFICATION REJECT at +236 ms |

```
amf  gmm/handler.go  WARN request type is initial request but payload is not a
                          PDU session establishment request (pdu session id: 10);
                          forwarding to SMF
```

The gate fires exactly once, on the one case that needs it, and not at all for the other two — it is selective rather than a blanket change to the uplink NAS path. In every case the single SMF purge is about a second before the modification, at establishment where it belongs; against the unpatched AMF, case 1 had a second purge at the modification itself. No 403 in any of the three.

What these runs do not cover is a genuine duplicate *establishment* still taking the delete path. Over-gating is the risk this change carries, and it is covered by the unit tests below, which mutation-verify each gate by reverting it individually.

## Two subtleties recorded in comments

Both are things a reviewer would otherwise have to derive, and one is a hazard.

**The nil check in `isEstablishmentRequestFromUE` is the short circuit.** `nas.Message` embeds
`*GsmMessage`, which embeds `GsmHeader` by value, so reading `msg.GsmHeader` when `GsmMessage` is
nil dereferences the pointer. Reordering those two operands would introduce a nil dereference on a
malformed payload, and nothing said the ordering was load-bearing.

**The `!establishmentOnExistingSession` guard is always true as the code stands.** An establishment
request on an existing session is consumed by the delete above, which clears `has` and skips the
switch. It is written as a condition rather than dropped because what follows it tears down a
working session, and that call should depend on the payload check explicitly rather than on the
reachability of a block above it.

## Testing

`gmm/establishment_payload_test.go`:

- `TestIsEstablishmentRequestFromUE` — the discriminator across establishment, modification, release, release-complete, empty and undecodable payloads.
- `TestModificationRequestWithInitialRequestTypeKeepsSmContext` — drives `transport5GSMMessage` and asserts the SM context survives a modification request carrying the wrong Request type.

Both gates were verified by reverting each individually and confirming the tests fail: gate 1 fails the assertion, gate 2 reaches `releaseDuplicatePDUSession`.

`gofmt`, `go vet`, and the `gmm` and `context` suites are clean.

