### PR TITLE
context, gmm: keep a pending N1N2 message readable, and stop storing from destroying it

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -12,7 +12,9 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -231,6 +233,49 @@ type AmfUe struct {
 	ProducerLog *zap.SugaredLogger `json:"-"`
 }
 
+// serialisablePendingMessage copies a pending N1N2 message into a form that can be
+// stored and read back.
+//
+// Two things went wrong here before. It shared the live JsonData pointer and then
+// replaced its containers with empty ones, so storing a context **destroyed** the
+// pending message it was storing -- the copy-back that followed only ever copied the
+// empty container onto itself. And the empty containers it wrote carried empty 3GPP
+// enum values, which the strict decoders reject, so the whole stored context became
+// undecodable: the AMF reported a UE that was present in the database as absent, and
+// answered 404 to a request to page it.
+//
+// So: copy rather than share, and omit a container that has no content rather than
+// writing one the reader will refuse.
+func serialisablePendingMessage(pending *N1N2Message) *N1N2Message {
+	if pending == nil {
+		return nil
+	}
+
+	stored := *pending
+
+	if pending.Request.JsonData == nil {
+		return &stored
+	}
+
+	jsonData := *pending.Request.JsonData
+
+	jsonData.N1MessageContainer = nil
+	if src := pending.Request.JsonData.N1MessageContainer; src != nil && src.GetN1MessageClass() != "" {
+		container := *src
+		jsonData.N1MessageContainer = &container
+	}
+
+	jsonData.N2InfoContainer = nil
+	if src := pending.Request.JsonData.N2InfoContainer; src != nil && src.GetN2InformationClass() != "" {
+		container := *src
+		jsonData.N2InfoContainer = &container
+	}
+
+	stored.Request.JsonData = &jsonData
+
+	return &stored
+}
+
 func (ue *AmfUe) MarshalJSON() ([]byte, error) {
 	// The encoder walks maps that other goroutines write while holding this very
 	// mutex -- RanUe is written by AttachRanUe and DetachRanUe -- so marshalling them
@@ -249,35 +294,22 @@ func (ue *AmfUe) MarshalJSON() ([]byte, error) {
 	smCtxListVal := make(map[string]SmContext)
 	var ranUeNgapIDVal, amfUeNgapIDVal int64
 	var gnbId string
-	if ue.RanUe != nil && ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] != nil {
-		gnbId = ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].Ran.GnbId
-		if ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] != nil {
-			ranUeNgapIDVal = ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].RanUeNgapId
-			amfUeNgapIDVal = ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].AmfUeNgapId
+	if ranUe := ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS]; ranUe != nil {
+		ranUeNgapIDVal = ranUe.RanUeNgapId
+		amfUeNgapIDVal = ranUe.AmfUeNgapId
+
+		// Guarded: a RanUe exists before it is attached to a RAN, and one restored from
+		// the database may have no live RAN at all. Storing such a context used to
+		// panic here.
+		if ranUe.Ran != nil {
+			gnbId = ranUe.Ran.GnbId
 		}
 	}
 
 	for access, state := range ue.State {
 		stateVal[access] = string(state.Current())
 	}
-	var n1n2MsgPtr *N1N2Message
-	if ue.N1N2Message != nil {
-		n1n2MsgVal := *ue.N1N2Message
-		n1n2MsgVal.Request = ue.N1N2Message.Request
-		n1n2MsgVal.Request.JsonData = models.NewN1N2MessageTransferReqData()
-		if ue.N1N2Message.Request.JsonData != nil {
-			n1n2MsgVal.Request.JsonData = ue.N1N2Message.Request.JsonData
-			n1n2MsgVal.Request.JsonData.N1MessageContainer = models.NewN1MessageContainerWithDefaults()
-			n1n2MsgVal.Request.JsonData.N2InfoContainer = models.NewN2InfoContainerWithDefaults()
-			if ue.N1N2Message.Request.JsonData.N1MessageContainer != nil {
-				*n1n2MsgVal.Request.JsonData.N1MessageContainer = *ue.N1N2Message.Request.JsonData.N1MessageContainer
-			}
-			if ue.N1N2Message.Request.JsonData.N2InfoContainer != nil {
-				*n1n2MsgVal.Request.JsonData.N2InfoContainer = *ue.N1N2Message.Request.JsonData.N2InfoContainer
-			}
-		}
-		n1n2MsgPtr = &n1n2MsgVal
-	}
+	n1n2MsgPtr := serialisablePendingMessage(ue.N1N2Message)
 
 	ue.SmContextList.Range(func(key, val interface{}) bool {
 		smContext := val.(*SmContext)
@@ -433,6 +465,59 @@ type N1N2Message struct {
 	Request     models.N1N2MessageTransferRequest
 	Status      models.N1N2MessageTransferCause
 	ResourceUri string
+	// N1Msg and N2Info hold the payloads as they were when the message was stored.
+	// Request's binary fields are readers that the transfer procedure has already
+	// drained, so reading them again yields nothing at all -- and no error.
+	N1Msg  []byte
+	N2Info []byte
+}
+
+// Payloads returns the N1 message and N2 information of a pending message.
+//
+// The bytes captured at storage time are authoritative. Reading Request's binary
+// fields again returns zero bytes and no error, because the transfer procedure
+// consumed them before storing the message: that is how a paged UE came back and
+// received a PDU Session Resource Setup carrying an empty transfer, leaving it
+// connected with no user plane and nothing in the log to say why. Reading the
+// fields is kept as a fallback for a message that predates the captured bytes,
+// and a container declared without content is now an error rather than an empty
+// item on the wire.
+func (m *N1N2Message) Payloads() ([]byte, []byte, error) {
+	n1Msg, n2Info := m.N1Msg, m.N2Info
+
+	if len(n1Msg) == 0 {
+		if f := m.Request.GetBinaryDataN1Message(); f != nil {
+			b, err := io.ReadAll(f)
+			if err != nil {
+				return nil, nil, fmt.Errorf("read stored N1 message: %w", err)
+			}
+
+			n1Msg = b
+		}
+	}
+
+	if len(n2Info) == 0 {
+		if f := m.Request.GetBinaryDataN2Information(); f != nil {
+			b, err := io.ReadAll(f)
+			if err != nil {
+				return nil, nil, fmt.Errorf("read stored N2 information: %w", err)
+			}
+
+			n2Info = b
+		}
+	}
+
+	if reqData := m.Request.JsonData; reqData != nil {
+		if reqData.HasN1MessageContainer() && len(n1Msg) == 0 {
+			return nil, nil, errors.New("N1MessageContainer present but BinaryDataN1Message is missing")
+		}
+
+		if reqData.HasN2InfoContainer() && len(n2Info) == 0 {
+			return nil, nil, errors.New("N2InfoContainer present but BinaryDataN2Information is missing")
+		}
+	}
+
+	return n1Msg, n2Info, nil
 }
 
 type OnGoingProcedureWithPrio struct {

--- a/context/db.go
+++ b/context/db.go
@@ -205,6 +205,36 @@ func DeleteContextFromDB(ue *AmfUe) {
 	}
 }
 
+// dropEmptyEnumValues removes keys whose value is an empty string, in place, walking
+// nested objects and arrays.
+//
+// Decoding an object into Go treats an absent key and an empty string identically -- the
+// field is left at its zero value -- with one exception: the strict 3GPP enum decoders
+// refuse an empty value, and refuse the whole document with it. A stored context that is
+// only partly populated therefore becomes unreadable, and it does not take much: an
+// optional container written with no class, or ngKsi.tsc on a UE stored before
+// authentication finished.
+//
+// This runs only after a strict decode has already failed, so a well-formed record is
+// never touched by it.
+func dropEmptyEnumValues(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, held := range typed {
+			if str, isString := held.(string); isString && str == "" {
+				delete(typed, key)
+				continue
+			}
+
+			dropEmptyEnumValues(held)
+		}
+	case []any:
+		for _, held := range typed {
+			dropEmptyEnumValues(held)
+		}
+	}
+}
+
 func DbFetch(collName string, filter bson.M) *AmfUe {
 	ue := &AmfUe{}
 	ue.init()
@@ -216,10 +246,30 @@ func DbFetch(collName string, filter bson.M) *AmfUe {
 	if len(result) == 0 {
 		return nil
 	}
+
 	err := sonic.Unmarshal(mapToByte(result), ue)
 	if err != nil {
-		logger.DataRepoLog.Errorf("amfue unmarshal error: %v", err)
-		return nil
+		// Retry without the empty values a strict enum decoder refuses. Records written
+		// before those values stopped being written are still in deployed databases,
+		// and a UE whose record cannot be read is a UE that cannot be paged.
+		strictErr := err
+
+		dropEmptyEnumValues(result)
+
+		ue = &AmfUe{}
+		ue.init()
+
+		if err = sonic.Unmarshal(mapToByte(result), ue); err != nil {
+			// Not the same thing as an absent document, and conflating them is what
+			// hid this for months: the context is there and unreadable, which is a
+			// fault to fix rather than a subscriber to go looking for.
+			logger.DataRepoLog.Errorf("stored UE context exists but could not be decoded: %v", err)
+
+			return nil
+		}
+
+		logger.DataRepoLog.Warnf("read a stored UE context that a strict decode refused (%v); "+
+			"empty values were dropped", strictErr)
 	}
 
 	dbMutex.Lock()

--- a/context/n1n2_payload_test.go
+++ b/context/n1n2_payload_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// drainedPayloadFile writes content to a temp file and reads it to EOF, which is the
+// state the transfer procedure leaves the request in before storing it.
+func drainedPayloadFile(t *testing.T, content []byte) *os.File {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open payload: %v", err)
+	}
+
+	t.Cleanup(func() { f.Close() })
+
+	if _, err := io.ReadAll(f); err != nil {
+		t.Fatalf("drain payload: %v", err)
+	}
+
+	return f
+}
+
+func pendingMessageWithN2Container(t *testing.T, f *os.File, captured []byte) *N1N2Message {
+	t.Helper()
+
+	jsonData := models.NewN1N2MessageTransferReqData()
+	jsonData.SetN2InfoContainer(*models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM))
+
+	request := models.NewN1N2MessageTransferRequest()
+	request.SetJsonData(*jsonData)
+	request.SetBinaryDataN2Information(f)
+
+	return &N1N2Message{Request: *request, N2Info: captured}
+}
+
+// A paged UE answers seconds after the message was stored, by which point the
+// request's reader is at EOF and returns zero bytes with no error. Without the
+// captured payload the AMF sent the RAN a PDU Session Resource Setup with an empty
+// transfer, so the UE reconnected with no user plane.
+func TestN1N2MessagePayloadsSurvivesDrainedReader(t *testing.T) {
+	want := []byte{0xde, 0xad, 0xbe, 0xef}
+	msg := pendingMessageWithN2Container(t, drainedPayloadFile(t, want), want)
+
+	_, n2Info, err := msg.Payloads()
+	if err != nil {
+		t.Fatalf("Payloads: unexpected error %v", err)
+	}
+
+	if string(n2Info) != string(want) {
+		t.Errorf("N2 information = %x, want %x", n2Info, want)
+	}
+}
+
+// A declared container with nothing behind it must fail loudly rather than produce an
+// empty item on the wire.
+func TestN1N2MessagePayloadsRejectsDeclaredButEmptyContainer(t *testing.T) {
+	msg := pendingMessageWithN2Container(t, drainedPayloadFile(t, []byte{0x01}), nil)
+
+	if _, _, err := msg.Payloads(); err == nil {
+		t.Fatal("Payloads: want an error for a declared N2 container with no content, got nil")
+	}
+}
+
+// Nothing declared, nothing captured: not an error, just no payloads.
+func TestN1N2MessagePayloadsAllowsNoContainers(t *testing.T) {
+	request := models.NewN1N2MessageTransferRequest()
+	request.SetJsonData(*models.NewN1N2MessageTransferReqData())
+
+	msg := &N1N2Message{Request: *request}
+
+	n1Msg, n2Info, err := msg.Payloads()
+	if err != nil {
+		t.Fatalf("Payloads: unexpected error %v", err)
+	}
+
+	if len(n1Msg) != 0 || len(n2Info) != 0 {
+		t.Errorf("payloads = (%x, %x), want empty", n1Msg, n2Info)
+	}
+}

--- a/context/pending_message_storage_test.go
+++ b/context/pending_message_storage_test.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// pendingN2OnlyMessage is the shape a DDN-triggered page stores: N2 information and no
+// N1 message, which is exactly the case that used to make a stored context unreadable.
+// These JSON keys are repeated across the tables below; goconst asks for names.
+const (
+	n2InfoContainerKey = "n2InfoContainer"
+	n2InformationClass = "n2InformationClass"
+)
+
+func pendingN2OnlyMessage() *N1N2Message {
+	jsonData := models.NewN1N2MessageTransferReqData()
+	jsonData.SetPduSessionId(1)
+	jsonData.SetN2InfoContainer(*models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM))
+
+	request := models.NewN1N2MessageTransferRequest()
+	request.SetJsonData(*jsonData)
+
+	return &N1N2Message{
+		Request: *request,
+		Status:  models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE,
+		N2Info:  []byte{0x01, 0x02, 0x03},
+	}
+}
+
+func ueWithPendingMessage(t *testing.T) *AmfUe {
+	t.Helper()
+
+	ue := &AmfUe{}
+	ue.init()
+	ue.Supi = "imsi-208930100007488"
+	ue.N1N2Message = pendingN2OnlyMessage()
+
+	return ue
+}
+
+// The regression: storing a context wrote optional containers carrying empty 3GPP enum
+// values, and the strict decoders refuse those, so the whole context could not be read
+// back. The AMF then reported a UE that was present in the database as absent.
+func TestStoredContextWithPendingMessageRoundTrips(t *testing.T) {
+	ue := ueWithPendingMessage(t)
+
+	stored, err := sonic.Marshal(ue)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Decode the way DbFetch does, so the read-path tolerance is part of the test: a
+	// partly-populated context carries other empty enum values too -- ngKsi.tsc on a UE
+	// stored before authentication finished, for one.
+	var asStored map[string]any
+	if err := sonic.Unmarshal(stored, &asStored); err != nil {
+		t.Fatalf("re-read stored form: %v", err)
+	}
+
+	restored := &AmfUe{}
+	restored.init()
+
+	if err := sonic.Unmarshal(stored, restored); err != nil {
+		dropEmptyEnumValues(asStored)
+
+		relaxed, marshalErr := sonic.Marshal(asStored)
+		if marshalErr != nil {
+			t.Fatalf("marshal relaxed form: %v", marshalErr)
+		}
+
+		if err := sonic.Unmarshal(relaxed, restored); err != nil {
+			t.Fatalf("a stored context must be readable, got: %v", err)
+		}
+	}
+
+	if restored.Supi != ue.Supi {
+		t.Errorf("restored SUPI = %q, want %q", restored.Supi, ue.Supi)
+	}
+
+	// The payload is the point: a restored message whose content did not survive
+	// produces a PDU Session Resource Setup with an empty transfer, which is how a paged
+	// UE came back with no user plane.
+	if restored.N1N2Message == nil {
+		t.Fatal("the restored context carries no pending message")
+	}
+
+	if got := string(restored.N1N2Message.N2Info); got != string(ue.N1N2Message.N2Info) {
+		t.Errorf("restored N2 information = %x, want %x", restored.N1N2Message.N2Info, ue.N1N2Message.N2Info)
+	}
+
+	if _, n2Info, err := restored.N1N2Message.Payloads(); err != nil {
+		t.Errorf("Payloads on a restored message: %v", err)
+	} else if string(n2Info) != string(ue.N1N2Message.N2Info) {
+		t.Errorf("Payloads N2 information = %x, want %x", n2Info, ue.N1N2Message.N2Info)
+	}
+}
+
+// Storing shared the live JsonData pointer and replaced its containers with empty ones,
+// so the act of storing a context destroyed the pending message inside it.
+func TestStoringDoesNotDestroyThePendingMessage(t *testing.T) {
+	ue := ueWithPendingMessage(t)
+
+	if _, err := sonic.Marshal(ue); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	container := ue.N1N2Message.Request.JsonData.N2InfoContainer
+	if container == nil {
+		t.Fatal("the live pending message lost its N2 container while being stored")
+	}
+
+	if got := container.GetN2InformationClass(); got != models.N2INFORMATIONCLASS_SM {
+		t.Errorf("N2 information class = %q after storing, want %q", got, models.N2INFORMATIONCLASS_SM)
+	}
+}
+
+func TestSerialisablePendingMessageOmitsContainersWithNoClass(t *testing.T) {
+	jsonData := models.NewN1N2MessageTransferReqData()
+	jsonData.SetN1MessageContainer(*models.NewN1MessageContainerWithDefaults())
+	jsonData.SetN2InfoContainer(*models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM))
+
+	request := models.NewN1N2MessageTransferRequest()
+	request.SetJsonData(*jsonData)
+
+	stored := serialisablePendingMessage(&N1N2Message{Request: *request})
+	if stored == nil {
+		t.Fatal("serialisablePendingMessage returned nil for a non-nil message")
+	}
+
+	if stored.Request.JsonData.N1MessageContainer != nil {
+		t.Error("an N1 container with no class must be omitted, not stored empty")
+	}
+
+	if stored.Request.JsonData.N2InfoContainer == nil {
+		t.Error("an N2 container with a class must be kept")
+	}
+}
+
+// Records written before the fix are still in deployed databases, and a UE that had ever
+// been paged stayed unreachable until it re-registered.
+func TestDropEmptyEnumValuesHealsLegacyRecords(t *testing.T) {
+	doc := map[string]any{
+		"customFieldsAmfUe": map[string]any{
+			"n1n2Msg": map[string]any{
+				"Request": map[string]any{
+					"jsonData": map[string]any{
+						"n1MessageContainer": map[string]any{"n1MessageClass": ""},
+						n2InfoContainerKey:   map[string]any{n2InformationClass: ""},
+					},
+				},
+			},
+		},
+	}
+
+	dropEmptyEnumValues(doc)
+
+	jsonData := doc["customFieldsAmfUe"].(map[string]any)["n1n2Msg"].(map[string]any)["Request"].(map[string]any)["jsonData"].(map[string]any)
+
+	// The container may remain as an empty object -- that decodes cleanly. What must be
+	// gone is the empty class value, which is what a strict decoder refuses.
+	for container, classField := range map[string]string{
+		"n1MessageContainer": "n1MessageClass",
+		n2InfoContainerKey:   "n2InformationClass",
+	} {
+		held, present := jsonData[container].(map[string]any)
+		if !present {
+			continue
+		}
+
+		if _, stillThere := held[classField]; stillThere {
+			t.Errorf("%s.%s was empty and must have been dropped", container, classField)
+		}
+	}
+}
+
+func TestDropEmptyEnumValuesKeepsRealContent(t *testing.T) {
+	doc := map[string]any{
+		"customFieldsAmfUe": map[string]any{
+			"n1n2Msg": map[string]any{
+				"Request": map[string]any{
+					"jsonData": map[string]any{
+						n2InfoContainerKey: map[string]any{n2InformationClass: "SM"},
+					},
+				},
+			},
+		},
+	}
+
+	dropEmptyEnumValues(doc)
+
+	jsonData := doc["customFieldsAmfUe"].(map[string]any)["n1n2Msg"].(map[string]any)["Request"].(map[string]any)["jsonData"].(map[string]any)
+	if _, present := jsonData[n2InfoContainerKey]; !present {
+		t.Error("a container carrying a class must be left alone")
+	}
+}
+
+// A context whose RanUe has no RAN yet, or none any more, must still be storable.
+func TestMarshalToleratesARanUeWithNoRan(t *testing.T) {
+	ue := ueWithPendingMessage(t)
+	ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] = &RanUe{RanUeNgapId: 7, AmfUeNgapId: 9}
+
+	if _, err := sonic.Marshal(ue); err != nil {
+		t.Fatalf("storing a context with no RAN attached must not fail: %v", err)
+	}
+}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -57,6 +58,28 @@ var (
 	amPolicyControlCreateForRegistration  = consumer.AMPolicyControlCreate
 	sendRegistrationAcceptForRegistration = gmm_message.SendRegistrationAccept
 )
+
+// removePendingPayloadFiles deletes the temp files openapi.Decode created for a pending
+// message's binary parts.
+//
+// Payloads prefers the bytes captured when the message was stored and may never touch the
+// files, but nothing else removes them: reading them here is what used to do it, so taking
+// the read away would reinstate the leak fixed upstream in #799. One file per paged UE, and
+// a UE paged repeatedly leaves one per attempt.
+func removePendingPayloadFiles(m *context.N1N2Message) {
+	if m == nil {
+		return
+	}
+
+	for _, f := range []*os.File{
+		m.Request.GetBinaryDataN1Message(),
+		m.Request.GetBinaryDataN2Information(),
+	} {
+		if _, err := util.ReadAndCleanupBinaryTempFile(f); err != nil {
+			logger.GmmLog.Warnf("could not remove a pending N1N2 message temp file: %+v", err)
+		}
+	}
+}
 
 func HandleULNASTransport(ctx ctxt.Context, ue *context.AmfUe, anType models.AccessType,
 	ulNasTransport *nasMessage.ULNASTransport,
@@ -1174,34 +1197,18 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx ctxt.Context, ue *context
 		n1n2Message := ue.N1N2Message
 		if n1n2Message != nil {
 			requestData := n1n2Message.Request.JsonData
-			n1MsgFile := n1n2Message.Request.GetBinaryDataN1Message()
-			n2InfoFile := n1n2Message.Request.GetBinaryDataN2Information()
 
-			if requestData.HasN1MessageContainer() && n1MsgFile == nil {
-				logger.GmmLog.Errorf("N1MessageContainer present but BinaryDataN1Message is missing")
-				return fmt.Errorf("N1MessageContainer present but BinaryDataN1Message is missing")
-			}
-			if requestData.HasN2InfoContainer() && n2InfoFile == nil {
-				logger.GmmLog.Errorf("N2InfoContainer present but BinaryDataN2Information is missing")
-				return fmt.Errorf("N2InfoContainer present but BinaryDataN2Information is missing")
+			// Take the payloads captured when the message was stored. Re-reading the
+			// request's binary fields returns nothing and no error, so an empty
+			// payload used to travel to the RAN as a PDU Session Resource Setup with
+			// no transfer in it.
+			n1Msg, n2Info, err := n1n2Message.Payloads()
+			if err != nil {
+				logger.GmmLog.Errorf("pending N1N2 message unusable: %+v", err)
+				return err
 			}
 
-			var n1Msg, n2Info []byte
-			var err error
-			if n1MsgFile != nil {
-				n1Msg, err = util.ReadAndCleanupBinaryTempFile(n1MsgFile)
-				if err != nil {
-					logger.GmmLog.Errorf("error reading BinaryDataN1Message: %+v", err)
-					return err
-				}
-			}
-			if n2InfoFile != nil {
-				n2Info, err = util.ReadAndCleanupBinaryTempFile(n2InfoFile)
-				if err != nil {
-					logger.GmmLog.Errorf("error reading BinaryDataN2Information: %+v", err)
-					return err
-				}
-			}
+			removePendingPayloadFiles(n1n2Message)
 			// downlink signalling
 			if n2Info == nil {
 				if len(suList.List) != 0 {
@@ -2149,34 +2156,18 @@ func HandleServiceRequest(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 	case nasMessage.ServiceTypeMobileTerminatedServices: // Trigger by Network
 		if n1n2Message != nil {
 			requestData := n1n2Message.Request.JsonData
-			n1MsgFile := n1n2Message.Request.GetBinaryDataN1Message()
-			n2InfoFile := n1n2Message.Request.GetBinaryDataN2Information()
 
-			if requestData.HasN1MessageContainer() && n1MsgFile == nil {
-				logger.GmmLog.Errorf("N1MessageContainer present but BinaryDataN1Message is missing")
-				return fmt.Errorf("N1MessageContainer present but BinaryDataN1Message is missing")
-			}
-			if requestData.HasN2InfoContainer() && n2InfoFile == nil {
-				logger.GmmLog.Errorf("N2InfoContainer present but BinaryDataN2Information is missing")
-				return fmt.Errorf("N2InfoContainer present but BinaryDataN2Information is missing")
+			// Take the payloads captured when the message was stored. Re-reading the
+			// request's binary fields returns nothing and no error, so an empty
+			// payload used to travel to the RAN as a PDU Session Resource Setup with
+			// no transfer in it.
+			n1Msg, n2Info, err := n1n2Message.Payloads()
+			if err != nil {
+				logger.GmmLog.Errorf("pending N1N2 message unusable: %+v", err)
+				return err
 			}
 
-			var n1Msg, n2Info []byte
-			var err error
-			if n1MsgFile != nil {
-				n1Msg, err = util.ReadAndCleanupBinaryTempFile(n1MsgFile)
-				if err != nil {
-					logger.GmmLog.Errorf("error reading BinaryDataN1Message: %+v", err)
-					return err
-				}
-			}
-			if n2InfoFile != nil {
-				n2Info, err = util.ReadAndCleanupBinaryTempFile(n2InfoFile)
-				if err != nil {
-					logger.GmmLog.Errorf("error reading BinaryDataN2Information: %+v", err)
-					return err
-				}
-			}
+			removePendingPayloadFiles(n1n2Message)
 			// downlink signalling
 			if n2Info == nil {
 				err = sendServiceAccept(ue, anType, ctxList, suList, acceptPduSessionPsi,

--- a/producer/n1n2message.go
+++ b/producer/n1n2message.go
@@ -363,6 +363,8 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 				Request:     n1n2MessageTransferRequest,
 				Status:      n1n2MessageTransferRspData.Cause,
 				ResourceUri: locationHeader,
+				N1Msg:       n1Msg,
+				N2Info:      n2Info,
 			}
 			ue.N1N2Message = &message
 			ue.SetOnGoing(anType, &context.OnGoingProcedureWithPrio{
@@ -405,6 +407,8 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 					Request:     n1n2MessageTransferRequest,
 					Status:      n1n2MessageTransferRspData.Cause,
 					ResourceUri: locationHeader,
+					N1Msg:       n1Msg,
+					N2Info:      n2Info,
 				}
 				ue.N1N2Message = &message
 				nasMsg, err := gmm_message.BuildNotification(ue, models.ACCESSTYPE_NON_3_GPP_ACCESS)
@@ -427,6 +431,8 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 				Request:     n1n2MessageTransferRequest,
 				Status:      n1n2MessageTransferRspData.Cause,
 				ResourceUri: locationHeader,
+				N1Msg:       n1Msg,
+				N2Info:      n2Info,
 			}
 			ue.N1N2Message = &message
 


### PR DESCRIPTION
### What this fixes

Three defects on one path. Each of them alone leaves a UE that cannot be reached with downlink
traffic, and they compose — fixing any one still ends in a UE with no user plane, arrived at from
a different direction.

**1. The payload was already consumed before the message was stored.**

`N1N2Message` held only the request, whose binary parts are readers. The transfer procedure drains
them to decide what to do, so by the time the message was stored for a later page, the payloads
were gone. A paged UE then came back and received a `PDUSessionResourceSetupRequest` carrying an
**empty transfer** — connected, with no user plane, and nothing in the log to say why.

**2. Storing a context destroyed the message inside it.**

`MarshalJSON` materialised empty optional containers on the live `JsonData` — the same pointer the
pending message holds. So persisting a context emptied the pending message it was persisting.

**3. A stored context could not be read back at all.**

Those empty containers are written as `n1MessageClass:""` and `n2InformationClass:""`, and the
strict 3GPP enum decoders refuse an empty value — refusing the whole document with it.

This turned out to be a *class* of defect rather than two fields: after fixing both containers, a
round trip still failed on `ngKsi.tsc`, which is empty on any UE stored before authentication
finished. A test is what found that; inspection did not.

### What changes

- The payload bytes are captured alongside the request, and a `Payloads` accessor returns them,
  reading the request only as a fallback for a message stored before this change. A container
  declared with nothing behind it is now an error rather than an empty item on the wire.
- Storing serialises from a **copy**, and omits a container carrying no class rather than writing
  it empty.
- The read path keeps its strict decode and, **only when that fails**, drops empty values and
  retries once, logging that it did. This is safe for a reason worth stating: decoding treats an
  absent key and an empty string identically — the field is left at its zero value — and only the
  strict enum decoders distinguish them, by refusing everything. The write path stops producing
  such records, so the tolerance exists purely for what is already in deployed databases.
- `DbFetch` mapped *any* unmarshal error to nil, which the caller reports as "no document found".
  That is what hid this for so long: "no document found" describes a missing subscriber, not a
  record that is present and unreadable. They are now different log lines.
- Guards `MarshalJSON`'s unchecked `RanUe.Ran` dereference, which panicked when storing a context
  whose `RanUe` had no RAN — one restored from the database, or one not yet attached.

### Testing

`linux/amd64`, in the images CI pins:

- `go test -race ./...` — **all packages green** in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

The tests are mutation-checked rather than assumed: restoring the pre-fix container
materialisation makes `TestStoredContextWithPendingMessageRoundTrips` fail with
`Payloads on a restored message: N1MessageContainer present but BinaryDataN1Message is missing`,
and `TestSerialisablePendingMessageOmitsContainersWithNoClass` fail as well. Both pass with the
fix.

Verified end to end on a live deployment: a page now produces an `InitialContextSetupRequest`
whose PDU session transfer carries 4 IEs and 36 bytes, where it previously carried none, and the
UE's user plane returns 18 ms after the page.

### Note for reviewers

The read-path tolerance is the part I would most like a second opinion on. It is deliberately
scoped to the persistence path and to a retry *after* a strict decode has already failed, so a
well-formed record never goes near it. The alternative — relaxing the shared enum decoders in
`openapi/models` to accept `""` — would weaken wire validation for every NF, where an empty class
really is invalid. If you would rather this healed records by a migration instead, I am happy to
do it that way; the writer fix stands either way.
