### PR TITLE
ngap, producer: page a UE instead of sending N2 into a connection that is gone

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -668,6 +668,40 @@ func (ue *AmfUe) CmConnect(anType models.AccessType) bool {
 	return true
 }
 
+// HasLiveRanConnection reports whether an N2 message for this UE can actually reach a
+// RAN node right now.
+//
+// This is a narrower question than CmConnect, which answers "is this UE associated
+// over this access type" and is used for lookups where a stale RanUe is acceptable --
+// GetAnType is one such caller.
+//
+// A record of a past connection is not a connection. A context restored from the
+// database carries a RanUe, and that RanUe carries an AmfRan, but only the fields that
+// survive serialisation: Conn and Amf2RanMsgChan are json:"-" and come back nil, as
+// does the logger. Treating that as connected sent N2 messages into an association
+// that no longer existed, panicked in the send path on the nil logger, had the panic
+// swallowed by a recover that blamed the gNB, and still answered the SMF as though the
+// message had gone -- so an idle UE stayed unreachable after every AMF restart,
+// because nothing ever paged it.
+func (ue *AmfUe) HasLiveRanConnection(anType models.AccessType) bool {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ranUe, ok := ue.RanUe[anType]
+	if !ok || ranUe == nil || ranUe.Ran == nil {
+		return false
+	}
+
+	// Under SCTP load balancing the AMF holds no socket of its own: messages leave
+	// through a channel, so Conn being nil means nothing there and the channel is what
+	// has to exist.
+	if AMF_Self().EnableSctpLb {
+		return ranUe.Ran.Amf2RanMsgChan != nil
+	}
+
+	return ranUe.Ran.Conn != nil
+}
+
 func (ue *AmfUe) CmIdle(anType models.AccessType) bool {
 	return !ue.CmConnect(anType)
 }

--- a/context/cm_state_test.go
+++ b/context/cm_state_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"net"
+	"testing"
+
+	"github.com/omec-project/amf/protos/sdcoreAmfServer"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// restoredRan is the shape an AmfRan comes back in from the database: the serialisable
+// fields survive, the transport and the logger do not.
+func restoredRan() *AmfRan {
+	return &AmfRan{RanPresent: RanPresentGNbId}
+}
+
+func ueWithRanUe(ranUe *RanUe) *AmfUe {
+	ue := &AmfUe{}
+	ue.init()
+	ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] = ranUe
+
+	return ue
+}
+
+func withSctpLb(t *testing.T, enabled bool) {
+	t.Helper()
+
+	previous := AMF_Self().EnableSctpLb
+	AMF_Self().EnableSctpLb = enabled
+
+	t.Cleanup(func() { AMF_Self().EnableSctpLb = previous })
+}
+
+func TestHasLiveRanConnectionRequiresALiveTransport(t *testing.T) {
+	withSctpLb(t, false)
+
+	liveConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("open a connection to stand in for the association: %v", err)
+	}
+
+	defer liveConn.Close()
+
+	tests := []struct {
+		name string
+		ue   *AmfUe
+		want bool
+	}{
+		{
+			name: "no RanUe for the access type",
+			ue: func() *AmfUe {
+				ue := &AmfUe{}
+				ue.init()
+				return ue
+			}(),
+			want: false,
+		},
+		{
+			name: "RanUe present but nil",
+			ue:   ueWithRanUe(nil),
+			want: false,
+		},
+		{
+			name: "RanUe with no Ran at all",
+			ue:   ueWithRanUe(&RanUe{}),
+			want: false,
+		},
+		{
+			// The case that mattered: a context restored from the database.
+			name: "RanUe with a Ran restored without its transport",
+			ue:   ueWithRanUe(&RanUe{Ran: restoredRan()}),
+			want: false,
+		},
+		{
+			name: "RanUe with a live association",
+			ue:   ueWithRanUe(&RanUe{Ran: &AmfRan{Conn: liveConn}}),
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ue.HasLiveRanConnection(models.ACCESSTYPE__3_GPP_ACCESS); got != tc.want {
+				t.Errorf("HasLiveRanConnection() = %t, want %t", got, tc.want)
+			}
+
+			// CmConnect deliberately still answers the wider question -- is this UE
+			// associated over this access type -- because callers like GetAnType rely
+			// on it for lookups where a stale RanUe is acceptable.
+			if _, keyed := tc.ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS]; keyed &&
+				!tc.ue.CmConnect(models.ACCESSTYPE__3_GPP_ACCESS) {
+				t.Error("CmConnect() = false while a RanUe key exists; its meaning must not have changed")
+			}
+		})
+	}
+}
+
+// Under SCTP load balancing the AMF holds no socket, so the channel is what has to
+// exist -- judging by Conn there would report every UE as idle.
+func TestHasLiveRanConnectionUnderSctpLoadBalancing(t *testing.T) {
+	withSctpLb(t, true)
+
+	restored := ueWithRanUe(&RanUe{Ran: restoredRan()})
+	if restored.HasLiveRanConnection(models.ACCESSTYPE__3_GPP_ACCESS) {
+		t.Error("HasLiveRanConnection() = true for a restored context, want false")
+	}
+
+	live := ueWithRanUe(&RanUe{Ran: &AmfRan{
+		Amf2RanMsgChan: make(chan *sdcoreAmfServer.AmfMessage, 1),
+	}})
+	if !live.HasLiveRanConnection(models.ACCESSTYPE__3_GPP_ACCESS) {
+		t.Error("HasLiveRanConnection() = false with a live message channel, want true")
+	}
+}

--- a/ngap/error_indication_recovery_test.go
+++ b/ngap/error_indication_recovery_test.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package ngap
+
+import (
+	"testing"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/ngap/v2/ngapType"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// pendingMessage is the shape a DDN-triggered transfer leaves behind: N2 information the
+// AMF is holding on the SMF's behalf.
+func pendingMessage() *context.N1N2Message {
+	return &context.N1N2Message{
+		Status: models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE,
+		N2Info: []byte{0x01, 0x02, 0x03},
+	}
+}
+
+// staleUeErrorIndication is what a gNB sends when the AMF addresses it about a UE the gNB
+// has already let go.
+func staleUeErrorIndication() *ngapType.Cause {
+	cause := &ngapType.Cause{Present: ngapType.CausePresentRadioNetwork}
+	cause.RadioNetwork = new(ngapType.CauseRadioNetwork)
+	cause.RadioNetwork.Value = ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID
+
+	return cause
+}
+
+func ranWithPagedUe(t *testing.T, ranUeNgapID int64) (*context.AmfRan, *context.RanUe, *context.AmfUe) {
+	t.Helper()
+
+	ran := context.NewAmfRanDefault()
+	ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
+
+	ranUe, err := ran.NewRanUe(ranUeNgapID)
+	if err != nil {
+		t.Fatalf("create RanUe: %v", err)
+	}
+
+	ranUe.Log = logger.NgapLog
+
+	amfUe := context.AMF_Self().NewAmfUe("")
+	amfUe.AttachRanUe(ranUe)
+	amfUe.N1N2Message = pendingMessage()
+
+	// Paging is addressed by 5G-S-TMSI and bounded by the registration area, so a UE
+	// without both is not pageable and would exercise the build-failure branch instead.
+	amfUe.Guti = "20893cafe0000000001"
+	amfUe.RegistrationArea[models.ACCESSTYPE__3_GPP_ACCESS] = []models.Tai{
+		{PlmnId: models.PlmnId{Mcc: "208", Mnc: "93"}, Tac: "000001"},
+	}
+
+	return ran, ranUe, amfUe
+}
+
+// The defect: the AMF chose N2 over paging because the UE looked connected, the write
+// succeeded, and it answered N1N2_TRANSFER_INITIATED -- so nothing upstream retries. This
+// indication is the only notice it gets that the message went nowhere.
+func TestErrorIndicationForAStaleUeIdReleasesTheContextAndPages(t *testing.T) {
+	ran, ranUe, amfUe := ranWithPagedUe(t, 11)
+	amfUeNgapID := ranUe.AmfUeNgapId
+
+	recoverPendingMessageAfterStaleUeNgapID(ran, amfUeNgapIDIe(amfUeNgapID), nil,
+		staleUeErrorIndication())
+
+	if context.AMF_Self().RanUeFindByAmfUeNgapIDLocal(amfUeNgapID) != nil {
+		t.Error("the stale UE context is still held; the next transfer would repeat the failure")
+	}
+
+	if amfUe.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] != nil {
+		t.Error("the UE still points at the released RanUe, so it still looks connected")
+	}
+
+	if got := amfUe.GetOnGoing(models.ACCESSTYPE__3_GPP_ACCESS).Procedure; got != context.OnGoingProcedurePaging {
+		t.Errorf("ongoing procedure = %q, want %q", got, context.OnGoingProcedurePaging)
+	}
+
+	// The pending message must survive: it is what the paging exists to deliver.
+	if amfUe.N1N2Message == nil {
+		t.Error("the pending message was discarded, so the page has nothing to deliver")
+	}
+}
+
+// Every other error indication must be inert. Releasing a UE context on, say, a protocol
+// cause would turn a transient complaint into a dropped session.
+func TestErrorIndicationWithAnotherCauseChangesNothing(t *testing.T) {
+	ran, ranUe, amfUe := ranWithPagedUe(t, 12)
+	amfUeNgapID := ranUe.AmfUeNgapId
+
+	other := &ngapType.Cause{Present: ngapType.CausePresentRadioNetwork}
+	other.RadioNetwork = new(ngapType.CauseRadioNetwork)
+	other.RadioNetwork.Value = ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost
+
+	recoverPendingMessageAfterStaleUeNgapID(ran, amfUeNgapIDIe(amfUeNgapID), nil, other)
+
+	if context.AMF_Self().RanUeFindByAmfUeNgapIDLocal(amfUeNgapID) == nil {
+		t.Error("a UE context was released on a cause that does not say the id is unknown")
+	}
+
+	if got := amfUe.GetOnGoing(models.ACCESSTYPE__3_GPP_ACCESS).Procedure; got == context.OnGoingProcedurePaging {
+		t.Error("paging was started on a cause that does not say the id is unknown")
+	}
+}
+
+// The AMF-assigned id is unique across the AMF, not within one gNB, so a peer naming
+// another gNB's UE must not be able to have that subscriber's context destroyed.
+func TestErrorIndicationFromAnotherGnbIsIgnored(t *testing.T) {
+	_, ranUe, _ := ranWithPagedUe(t, 13)
+	amfUeNgapID := ranUe.AmfUeNgapId
+
+	unrelated := context.NewAmfRanDefault()
+	unrelated.AnType = models.ACCESSTYPE__3_GPP_ACCESS
+
+	recoverPendingMessageAfterStaleUeNgapID(unrelated, amfUeNgapIDIe(amfUeNgapID), nil,
+		staleUeErrorIndication())
+
+	if context.AMF_Self().RanUeFindByAmfUeNgapIDLocal(amfUeNgapID) == nil {
+		t.Error("an unrelated gNB had another gNB's UE context released on its word")
+	}
+}
+
+// Nothing pending means nothing to deliver: release the stale context, but do not page.
+func TestErrorIndicationWithNothingPendingDoesNotPage(t *testing.T) {
+	ran, ranUe, amfUe := ranWithPagedUe(t, 14)
+	amfUe.N1N2Message = nil
+	amfUeNgapID := ranUe.AmfUeNgapId
+
+	recoverPendingMessageAfterStaleUeNgapID(ran, amfUeNgapIDIe(amfUeNgapID), nil,
+		staleUeErrorIndication())
+
+	if context.AMF_Self().RanUeFindByAmfUeNgapIDLocal(amfUeNgapID) != nil {
+		t.Error("the stale UE context should still be released even with nothing pending")
+	}
+
+	if got := amfUe.GetOnGoing(models.ACCESSTYPE__3_GPP_ACCESS).Procedure; got == context.OnGoingProcedurePaging {
+		t.Error("paging was started with no pending message to deliver")
+	}
+}
+
+func amfUeNgapIDIe(value int64) *ngapType.AMFUENGAPID {
+	return &ngapType.AMFUENGAPID{Value: value}
+}
+
+// The defect was a handler that decoded, logged, and returned. Driving the real message
+// through it is what proves the recovery is actually wired in -- asserting on the helper
+// alone passes just as happily when nothing calls it.
+func TestHandleErrorIndicationRecoversThroughTheRealMessage(t *testing.T) {
+	ran, ranUe, amfUe := ranWithPagedUe(t, 15)
+	amfUeNgapID := ranUe.AmfUeNgapId
+
+	pdu := &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentInitiatingMessage,
+		InitiatingMessage: &ngapType.InitiatingMessage{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodeErrorIndication},
+			Value: ngapType.InitiatingMessageValue{
+				Present: ngapType.InitiatingMessagePresentErrorIndication,
+				ErrorIndication: &ngapType.ErrorIndication{
+					ProtocolIEs: ngapType.ProtocolIEContainerErrorIndicationIEs{
+						List: []ngapType.ErrorIndicationIEs{
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDAMFUENGAPID},
+								Value: ngapType.ErrorIndicationIEsValue{
+									Present:     ngapType.ErrorIndicationIEsPresentAMFUENGAPID,
+									AMFUENGAPID: &ngapType.AMFUENGAPID{Value: amfUeNgapID},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDRANUENGAPID},
+								Value: ngapType.ErrorIndicationIEsValue{
+									Present:     ngapType.ErrorIndicationIEsPresentRANUENGAPID,
+									RANUENGAPID: &ngapType.RANUENGAPID{Value: ranUe.RanUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDCause},
+								Value: ngapType.ErrorIndicationIEsValue{
+									Present: ngapType.ErrorIndicationIEsPresentCause,
+									Cause:   staleUeErrorIndication(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	HandleErrorIndication(ran, pdu)
+
+	if context.AMF_Self().RanUeFindByAmfUeNgapIDLocal(amfUeNgapID) != nil {
+		t.Error("HandleErrorIndication left the stale UE context in place")
+	}
+
+	if got := amfUe.GetOnGoing(models.ACCESSTYPE__3_GPP_ACCESS).Procedure; got != context.OnGoingProcedurePaging {
+		t.Errorf("ongoing procedure after HandleErrorIndication = %q, want %q",
+			got, context.OnGoingProcedurePaging)
+	}
+}

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -4845,7 +4845,120 @@ func HandleErrorIndication(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 		printCriticalityDiagnostics(ran, criticalityDiagnostics)
 	}
 
-	// TODO: handle error based on cause/criticalityDiagnostics
+	recoverPendingMessageAfterStaleUeNgapID(ran, aMFUENGAPID, rANUENGAPID, cause)
+
+	// TODO: handle the remaining causes and criticalityDiagnostics
+}
+
+// causeIsUnknownUeNgapID reports whether the gNB is saying it does not recognise the UE
+// this message was about -- as opposed to any of the many other things an error
+// indication can carry, none of which mean the UE context is stale.
+func causeIsUnknownUeNgapID(cause *ngapType.Cause) bool {
+	if cause == nil || cause.Present != ngapType.CausePresentRadioNetwork || cause.RadioNetwork == nil {
+		return false
+	}
+
+	switch cause.RadioNetwork.Value {
+	case ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
+		ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID:
+		return true
+	default:
+		return false
+	}
+}
+
+// recoverPendingMessageAfterStaleUeNgapID pages a UE whose gNB has just said it does not
+// know the UE-NGAP-ID the AMF addressed it by.
+//
+// This is the only notice the AMF gets. The procedure that chose to send over N2 rather
+// than page did so because this UE looked connected, the write to the gNB succeeded, and
+// it answered its caller N1N2_TRANSFER_INITIATED -- so nothing upstream is waiting, and
+// nothing will retry. Meanwhile the message the SMF handed over is still held here, and
+// the UE stays unreachable until it happens to come back on its own; observed once as
+// PDUSessionResourceSetupRequest followed by this indication, with the UE recovering 35 s
+// later by its own service request.
+//
+// No lock on this side could have prevented it: the AMF's view was self-consistent, and
+// it was the peer that had released the UE. Repairing the outcome is the remedy, not
+// trying to win a race that is not ours to win.
+func recoverPendingMessageAfterStaleUeNgapID(
+	ran *context.AmfRan,
+	amfUeNgapID *ngapType.AMFUENGAPID,
+	ranUeNgapID *ngapType.RANUENGAPID,
+	cause *ngapType.Cause,
+) {
+	if !causeIsUnknownUeNgapID(cause) {
+		return
+	}
+
+	ranUe := findRanUeByAmfNgapID(ran, amfUeNgapID)
+	if ranUe == nil {
+		ranUe = findRanUeByRanNgapID(ran, ranUeNgapID)
+	}
+
+	if ranUe == nil {
+		// Both sides agree the UE is not here, which is the one case where there is
+		// nothing to repair.
+		ran.Log.Infoln("error indication reports an unknown UE-NGAP-ID that this AMF does not hold either")
+		return
+	}
+
+	// The AMF-assigned id is unique across this AMF, not within one gNB, so the lookup
+	// above can land on a UE belonging to a different gNB. Removing that one and paging
+	// its subscriber on the word of an unrelated peer is worse than doing nothing.
+	if ranUe.Ran != ran {
+		ran.Log.Warnln("error indication names a UE-NGAP-ID held for a different gNB, ignoring it")
+		return
+	}
+
+	// Capture before removing: Remove clears the link in both directions.
+	amfUe := ranUe.AmfUe
+
+	// Remove first. The choice between sending over N2 and paging is made by asking
+	// whether this UE has a live connection, and that has to stop answering yes for a
+	// gNB that just said it does not know the UE -- otherwise the next transfer repeats
+	// this failure, and the paging below would be built for a UE that still looks
+	// connected.
+	if err := ranUe.Remove(); err != nil {
+		ran.Log.Errorf("could not remove the stale UE context: %v", err)
+	}
+
+	if amfUe == nil {
+		ran.Log.Infoln("released a stale UE context the gNB no longer knows; it carried no UE")
+		return
+	}
+
+	pending := amfUe.N1N2Message
+	if pending == nil {
+		amfUe.GmmLog.Infoln("released a stale UE context the gNB no longer knows; nothing was pending for it")
+		return
+	}
+
+	anType := ran.AnType
+	if onGoing := amfUe.GetOnGoing(anType); onGoing.Procedure == context.OnGoingProcedurePaging {
+		amfUe.GmmLog.Infoln("released a stale UE context; a paging procedure is already running for it")
+		return
+	}
+
+	amfUe.SetOnGoing(anType, &context.OnGoingProcedureWithPrio{
+		Procedure: context.OnGoingProcedurePaging,
+	})
+
+	pkg, err := ngap_message.BuildPaging(amfUe, nil, anType == models.ACCESSTYPE_NON_3_GPP_ACCESS)
+	if err != nil {
+		amfUe.GmmLog.Errorf("build paging after a stale UE-NGAP-ID failed: %v", err)
+		// Paging was never sent, so no T3513 will fire to clear the transient state set
+		// above; reset it so the UE is not left in an OnGoingProcedurePaging conflict.
+		amfUe.N1N2Message = nil
+		amfUe.SetOnGoing(anType, &context.OnGoingProcedureWithPrio{
+			Procedure: context.OnGoingProcedureNothing,
+		})
+
+		return
+	}
+
+	amfUe.GmmLog.Infoln("gNB does not know this UE; released the stale context and paging for the pending message")
+	ngap_message.SendPaging(amfUe, pkg)
 }
 
 func HandleCellTrafficTrace(ran *context.AmfRan, message *ngapType.NGAPPDU) {

--- a/ngap/message/send.go
+++ b/ngap/message/send.go
@@ -19,9 +19,12 @@ import (
 
 func SendToRan(ran *context.AmfRan, packet []byte) {
 	defer func() {
-		err := recover()
-		if err != nil {
-			logger.NgapLog.Warnf("send error, gNB may have been lost: %+v", err)
+		if err := recover(); err != nil {
+			// Do not attribute this to the gNB. A lost association is reported by the
+			// guards below; reaching here means the AMF itself was in a state it did
+			// not expect -- a RanUe restored from the database with no transport, for
+			// one -- and the message was not sent.
+			logger.NgapLog.Errorf("internal fault while sending to gNB, message not sent: %+v", err)
 		}
 	}()
 
@@ -30,12 +33,26 @@ func SendToRan(ran *context.AmfRan, packet []byte) {
 		return
 	}
 
+	// A restored AmfRan has no logger: its own guards must not be what panics.
+	ranLog := ran.Log
+	if ranLog == nil {
+		ranLog = logger.NgapLog
+	}
+
 	if len(packet) == 0 {
-		ran.Log.Errorln("packet len is 0")
+		ranLog.Errorln("packet len is 0")
 		return
 	}
 
 	if context.AMF_Self().EnableSctpLb {
+		// A send on a nil channel blocks for ever. A restored AmfRan has no channel --
+		// it does not survive storage -- so without this the caller does not fail, it
+		// stops, holding whatever it holds. The guard mirrors the nil-Conn one below.
+		if ran.Amf2RanMsgChan == nil {
+			ranLog.Errorln("Ran msg chan is nil")
+			return
+		}
+
 		msg := &sdcoreAmfServer.AmfMessage{VerboseMsg: "Message from AMF"}
 		msg.Msg = packet
 		msg.Msgtype = sdcoreAmfServer.MsgType_AMF_MSG
@@ -45,22 +62,22 @@ func SendToRan(ran *context.AmfRan, packet []byte) {
 		ran.Amf2RanMsgChan <- msg
 	} else {
 		if ran.Conn == nil {
-			ran.Log.Errorln("Ran conn is nil")
+			ranLog.Errorln("Ran conn is nil")
 			return
 		}
 
 		if ran.Conn.RemoteAddr() == nil {
-			ran.Log.Errorln("Ran addr is nil")
+			ranLog.Errorln("Ran addr is nil")
 			return
 		}
 
-		ran.Log.Debugln("send NGAP message To Ran")
+		ranLog.Debugln("send NGAP message To Ran")
 
 		if n, err := ran.Conn.Write(packet); err != nil {
-			ran.Log.Errorf("send error: %+v", err)
+			ranLog.Errorf("send error: %+v", err)
 			return
 		} else {
-			ran.Log.Debugf("Write %d bytes", n)
+			ranLog.Debugf("Write %d bytes", n)
 		}
 	}
 }

--- a/ngap/message/send_hollow_ran_test.go
+++ b/ngap/message/send_hollow_ran_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package message
+
+import (
+	"testing"
+	"time"
+
+	"github.com/omec-project/amf/context"
+)
+
+// A context read back from the database carries a whole AmfRan whose transport and logger
+// did not survive storage. Sending to one must fail and return, not panic on the nil
+// logger and not block for ever on the nil channel -- the caller has a pending message in
+// hand and needs control back to page instead.
+func TestSendToRanReturnsForARestoredRan(t *testing.T) {
+	for _, sctpLb := range []bool{false, true} {
+		previous := context.AMF_Self().EnableSctpLb
+		context.AMF_Self().EnableSctpLb = sctpLb
+
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+			// No Conn, no Amf2RanMsgChan, no Log: exactly what DbFetch produces.
+			SendToRan(&context.AmfRan{RanPresent: context.RanPresentGNbId}, []byte{0x00, 0x01})
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Errorf("SendToRan did not return with EnableSctpLb=%t", sctpLb)
+		}
+
+		context.AMF_Self().EnableSctpLb = previous
+	}
+}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -274,7 +274,7 @@ func AmPolicyControlUpdateNotifyUpdateProcedure(polAssoID string,
 		// use go routine to write response first to ensure the order of the procedure
 		go func() {
 			// UE is CM-Connected State
-			if ue.CmConnect(models.ACCESSTYPE__3_GPP_ACCESS) {
+			if ue.HasLiveRanConnection(models.ACCESSTYPE__3_GPP_ACCESS) {
 				gmm_message.SendConfigurationUpdateCommand(ue, models.ACCESSTYPE__3_GPP_ACCESS, nil)
 				// UE is CM-IDLE => paging
 			} else {

--- a/producer/n1n2message.go
+++ b/producer/n1n2message.go
@@ -259,7 +259,7 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 	}
 
 	// UE is CM-Connected
-	if ue.CmConnect(anType) {
+	if ue.HasLiveRanConnection(anType) {
 		var (
 			nasPdu []byte
 			err    error
@@ -396,7 +396,7 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string,
 	} else {
 		// Case B (UE is CM-IDLE in Non-3GPP access but CM-CONNECTED in 3GPP access and the associated
 		// access type is Non-3GPP access)in subclause 5.2.2.3.1.2 of TS29518
-		if ue.CmConnect(models.ACCESSTYPE__3_GPP_ACCESS) {
+		if ue.HasLiveRanConnection(models.ACCESSTYPE__3_GPP_ACCESS) {
 			if n2Info == nil {
 				n1n2MessageTransferRspData.Cause = models.N1N2MESSAGETRANSFERCAUSE_N1_N2_TRANSFER_INITIATED
 				gmm_message.SendDLNASTransport(ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS], models.ACCESSTYPE__3_GPP_ACCESS,


### PR DESCRIPTION
> **Stacked on #793.** The diff shown here includes that PR's commit until it merges; the commit
> to review is the second one. They are separable but both touch `context/amf_ue.go`, so this one
> is based on it to avoid a conflict.

### What this fixes

An idle UE stayed unreachable in two situations that end the same way: the AMF decides to send an
N2 message rather than page, the message does not arrive, and the SMF is told
`N1N2_TRANSFER_INITIATED`. Nothing waits and nothing retries, so the UE becomes reachable again
only when it happens to come back on its own.

**1. A record of a past connection is not a connection.**

A context restored from the database carries a `RanUe`, and that `RanUe` carries an `AmfRan` — but
only the fields that survive serialisation. `Conn`, `Amf2RanMsgChan` and the logger are `json:"-"`
and come back nil. Treating that as connected sent N2 into an association that no longer existed:

```
send PDU Session Resource Setup Request {amf_ue_ngap_id: AMF_UE_NGAP_ID:0}
send error, gNB may have been lost: nil pointer dereference
```
…and **zero Paging frames**, with HTTP 200 returned to the SMF.

`CmConnect` cannot be the test here. It answers a wider question — "is this UE associated over
this access type" — and is used for lookups where a stale `RanUe` is perfectly fine; `GetAnType`
is one such caller. Making it strict turns a Namf_Location 200 into a 404, which an existing test
catches. So this adds `HasLiveRanConnection` and uses it only at the three sites that choose
between an N2 send and a page.

Two things worth flagging, because both would have shipped as a confident non-fix:

- The obvious guard, `Ran == nil`, is **false** for a restored context — it is not empty, only its
  transport is missing.
- Under **SCTP load balancing** the AMF holds no socket at all; messages leave through a channel.
  A liveness test written against `Conn` alone would report every UE idle and break those
  deployments while fixing ours.

**2. `SendToRan` could fail in ways the caller could not see.**

Its own nil guards logged through the `AmfRan`'s logger, which a restored context does not have —
so the guard panicked and the `recover` attributed an internal fault to the gNB. And under SCTP
load balancing the send is a channel send: a restored context's channel is nil, so the caller did
not fail, it **stopped there for ever**, holding the message it meant to page for. The `recover`
stays — a dead peer should not take the AMF down — but it no longer launders an internal fault
into "gNB may have been lost".

**3. The gNB can refuse a message that was sent successfully.**

`HandleErrorIndication` decoded, logged, and returned on a `// TODO`. So a gNB answering
`unknown-local-UE-NGAP-ID` produced nothing at all: the write had succeeded and the procedure had
already answered the SMF. Observed as a `PDUSessionResourceSetupRequest`, that indication, and the
UE recovering 35 s later by its own service request.

For the two causes that mean the peer does not recognise the id, the stale context is now released
and the pending message is paged for. Releasing it **first** is what makes the paging decision
correct — the UE has to stop looking connected to a gNB that just said it does not know it, or the
next transfer repeats the failure identically.

### Testing

`linux/amd64`, in the images CI pins:

- `go test -race ./...` — **all packages green** in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

Mutation-checked rather than assumed. Removing the nil-channel guard hangs
`TestSendToRanReturnsForARestoredRan` for its full timeout; removing the ownership guard fails
`TestErrorIndicationFromAnotherGnbIsIgnored`; and removing the *call site* from
`HandleErrorIndication` fails `TestHandleErrorIndicationRecoversThroughTheRealMessage` — that last
test exists because an earlier version asserted only on the helper, which passes just as happily
when nothing calls it, the same shape as the defect itself.

On a live deployment the scenario that produced `AMF_UE_NGAP_ID:0` and zero Paging now produces
`send Paging to TAI({Mcc:208 Mnc:93}, Tac:000001)` and two Paging frames carrying the restored
UE's 5G-S-TMSI. Five further paging cycles all completed, page to restored user plane in 18 ms.

### Note for reviewers

- **The `ErrorIndication` recovery is scoped deliberately.** It acts only on
  `unknown-local-UE-NGAP-ID` / `inconsistent-remote-UE-NGAP-ID`, and only on a `RanUe` the sending
  gNB actually holds — the AMF-assigned id is unique across the AMF, not within one gNB, so an
  unrelated peer must not be able to have a subscriber's context released on its word.
- **No lock would have fixed #3.** The AMF's view was self-consistent; the peer had released the
  UE. Repairing the outcome is the remedy rather than trying to win a race that is not the AMF's
  to win. I mention it because "make the decision and the send atomic" is the natural first
  suggestion and it does not help here.
- **One half deliberately not built:** a locally failed write still reports success to the SMF.
  A failed write means the association is gone, which tears down the `AmfRan` and its `RanUe`s, so
  the next transfer pages correctly — and threading an error back through the 29 call sites of
  `SendToRan`/`SendToRanUe` to recover one in-flight message did not look like a good trade. Happy
  to do it if you disagree.
