### PR TITLE
feat: signal the extended NAS SM timer indication, from the orbit rather than from being satellite

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -301,6 +301,18 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 	if ue.RatType != "" {
 		smContextCreateData.SetRatType(ue.RatType)
 	}
+	// TS 24.501 subclause 4.23.4: tell the SMF when this UE's access warrants the extended NAS
+	// session management timer values, so its timers are chosen from the access rather than from
+	// configuration alone. Only NR(MEO) and NR(GEO) qualify — see UsesExtendedNasSmTimers, which
+	// is deliberately narrower than "is this non-terrestrial".
+	//
+	// Sent only when true. The field is optional and an SMF that reads it treats absence and false
+	// alike, so an explicit false would add a field to every request on every deployment to say
+	// nothing.
+	if ue.UsesExtendedNasSmTimers() {
+		smContextCreateData.SetExtendedNasSmTimerInd(true)
+		ue.GmmLog.Infof("signalling the extended NAS SM timer indication to the SMF for RAT type %s", ue.RatType)
+	}
 	// Forward the UE location to the SMF at session creation, mirroring the
 	// SmContextUpdateData paths that already do so. ue.Location is populated
 	// during registration (gmm/handler.go) from NGAP UpdateLocation.

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -301,10 +301,13 @@ func buildCreateSmContextRequest(ue *amf_context.AmfUe, smContext *amf_context.S
 	if ue.RatType != "" {
 		smContextCreateData.SetRatType(ue.RatType)
 	}
-	// TS 24.501 subclause 4.23.4: tell the SMF when this UE's access warrants the extended NAS
-	// session management timer values, so its timers are chosen from the access rather than from
-	// configuration alone. Only NR(MEO) and NR(GEO) qualify — see UsesExtendedNasSmTimers, which
-	// is deliberately narrower than "is this non-terrestrial".
+	// TS 24.501 subclause 4.23.4: "If the use of extended NAS timer for access via a satellite
+	// NG-RAN cell is indicated by the AMF ... the SMF shall calculate the value of the applicable
+	// NAS timer indicated in table 10.3.2 for access via a satellite NG-RAN cell." This is that
+	// indication, so the SMF's timers follow the access rather than configuration alone.
+	//
+	// Which accesses qualify is table 10.3.2 NOTE 5, not the subclause: NR(MEO) and NR(GEO) only.
+	// See UsesExtendedNasSmTimers, which is deliberately narrower than "is this non-terrestrial".
 	//
 	// Sent only when true. The field is optional and an SMF that reads it treats absence and false
 	// alike, so an explicit false would add a field to every request on every deployment to say

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -572,11 +572,15 @@ func (ue *AmfUe) CmIdle(anType models.AccessType) bool {
 // UsesExtendedNasSmTimers reports whether this UE's access warrants the extended NAS session
 // management timer values, which the AMF signals to the SMF as ExtendedNasSmTimerInd.
 //
-// TS 24.501 subclause 4.23.4 NOTE 5 names only NR(MEO) and NR(GEO). It is deliberately narrower
-// than IsNtn, which is true for NR(LEO) and NR(OTHER_SAT) as well: at 600 to 1200 km a LEO round
-// trip is tens of milliseconds, so the base timer values are conformant there and extending them
-// would delay every recovery for no reason. NR(OTHER_SAT) is unnamed by NOTE 5 and takes the base
-// values by the letter of the specification.
+// TS 24.501 table 10.3.2 (Timers of 5GS session management - SMF side) carries the satellite
+// values, and its NOTE 5 names only NR(MEO) and NR(GEO). Subclause 4.23.4 is what sends the SMF to
+// that table when the AMF indicates extended timers; the RAT types are named by the note, not by
+// the subclause.
+//
+// This is deliberately narrower than IsNtn, which is true for NR(LEO) and NR(OTHER_SAT) as well: at
+// 600 to 1200 km a LEO round trip is tens of milliseconds, so the base timer values are conformant
+// there and extending them would delay every recovery for no reason. NR(OTHER_SAT) is unnamed by
+// that note and takes the base values by the letter of the specification.
 //
 // The orbit reaches ue.RatType at registration, upgraded from the RATInformation the serving RAN
 // advertised for the TAC at NGSetup. Where a RAN advertises nothing — which is every RAN in

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -569,6 +569,27 @@ func (ue *AmfUe) CmIdle(anType models.AccessType) bool {
 	return !ue.CmConnect(anType)
 }
 
+// UsesExtendedNasSmTimers reports whether this UE's access warrants the extended NAS session
+// management timer values, which the AMF signals to the SMF as ExtendedNasSmTimerInd.
+//
+// TS 24.501 subclause 4.23.4 NOTE 5 names only NR(MEO) and NR(GEO). It is deliberately narrower
+// than IsNtn, which is true for NR(LEO) and NR(OTHER_SAT) as well: at 600 to 1200 km a LEO round
+// trip is tens of milliseconds, so the base timer values are conformant there and extending them
+// would delay every recovery for no reason. NR(OTHER_SAT) is unnamed by NOTE 5 and takes the base
+// values by the letter of the specification.
+//
+// The orbit reaches ue.RatType at registration, upgraded from the RATInformation the serving RAN
+// advertised for the TAC at NGSetup. Where a RAN advertises nothing — which is every RAN in
+// reach at the time of writing — RatType stays generic NR and this is false, so the deployment
+// runs on configured timer values rather than on a signalled indication.
+func (ue *AmfUe) UsesExtendedNasSmTimers() bool {
+	switch ue.RatType {
+	case models.RATTYPE_NR_MEO, models.RATTYPE_NR_GEO:
+		return true
+	}
+	return false
+}
+
 // IsNtn reports whether the UE is currently being served over NR
 // Non-Terrestrial access, based on the Rel-18 RatType set during
 // registration (see HandleRegistrationRequest).

--- a/context/extended_nas_sm_timer_test.go
+++ b/context/extended_nas_sm_timer_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"testing"
+
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// TS 24.501 subclause 4.23.4 NOTE 5 names NR(MEO) and NR(GEO) and no other access.
+//
+// The tempting shortcut is "is this non-terrestrial", which IsNtn already answers — and it is the
+// wrong question. A LEO round trip at 600 to 1200 km is tens of milliseconds, so the base timer
+// values are conformant there; extending them would delay every recovery on a constellation that
+// does not need it. NR(OTHER_SAT) is unnamed by NOTE 5 and takes the base values by the letter of
+// the specification.
+func TestExtendedNasSmTimersFollowTheOrbitNotMerelyBeingSatellite(t *testing.T) {
+	tests := []struct {
+		ratType models.RatType
+		want    bool
+	}{
+		{models.RATTYPE_NR_GEO, true},
+		{models.RATTYPE_NR_MEO, true},
+		{models.RATTYPE_NR_LEO, false},
+		{models.RATTYPE_NR_OTHER_SAT, false},
+		{models.RATTYPE_NR, false},
+		{models.RATTYPE_EUTRA, false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		name := string(tc.ratType)
+		if name == "" {
+			name = "unset"
+		}
+		t.Run(name, func(t *testing.T) {
+			ue := &AmfUe{RatType: tc.ratType}
+			if got := ue.UsesExtendedNasSmTimers(); got != tc.want {
+				t.Errorf("UsesExtendedNasSmTimers() = %v, want %v for RAT type %q", got, tc.want, tc.ratType)
+			}
+		})
+	}
+}
+
+// The two predicates must not be confused: every access this one accepts is non-terrestrial, and
+// not every non-terrestrial access qualifies. Pinning the relationship catches a later change that
+// redefines one in terms of the other.
+func TestExtendedNasSmTimersAreASubsetOfNonTerrestrial(t *testing.T) {
+	for _, ratType := range []models.RatType{
+		models.RATTYPE_NR_LEO, models.RATTYPE_NR_MEO,
+		models.RATTYPE_NR_GEO, models.RATTYPE_NR_OTHER_SAT,
+		models.RATTYPE_NR, models.RATTYPE_EUTRA,
+	} {
+		ue := &AmfUe{RatType: ratType}
+		if ue.UsesExtendedNasSmTimers() && !ue.IsNtn() {
+			t.Errorf("%q warrants extended timers but is not non-terrestrial", ratType)
+		}
+	}
+
+	leo := &AmfUe{RatType: models.RATTYPE_NR_LEO}
+	if !leo.IsNtn() || leo.UsesExtendedNasSmTimers() {
+		t.Error("NR(LEO) must be non-terrestrial and must not warrant extended timers; deriving one predicate from the other is the mistake this pins")
+	}
+}

--- a/context/extended_nas_sm_timer_test.go
+++ b/context/extended_nas_sm_timer_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/omec-project/openapi/v2/models"
 )
 
-// TS 24.501 subclause 4.23.4 NOTE 5 names NR(MEO) and NR(GEO) and no other access.
+// TS 24.501 table 10.3.2 NOTE 5 names NR(MEO) and NR(GEO) and no other access. Table 10.3.1 says
+// the same for the UE side in its NOTE 7; subclause 4.23.4 is the clause that routes the SMF to
+// table 10.3.2 when the AMF indicates extended timers.
 //
 // The tempting shortcut is "is this non-terrestrial", which IsNtn already answers — and it is the
 // wrong question. A LEO round trip at 600 to 1200 km is tens of milliseconds, so the base timer


### PR DESCRIPTION
## What

The AMF tells the SMF when a UE's access warrants the extended NAS session management timer values,
by setting `ExtendedNasSmTimerInd` in `SmContextCreateData`.

The field exists on the model and nothing has ever set it. 99 lines, of which 66 are tests.

## Why

TS 24.501 table 10.3.2, *Timers of 5GS session management – SMF side*, gives the NAS session
management timers a base value and a satellite one — T3591 is 16 s or 22 s — and the SMF has to know
which applies to a given session. Subclause 4.23.4 is what routes it there: *"If the use of extended
NAS timer for access via a satellite NG-RAN cell is indicated by the AMF … the SMF shall calculate
the value of the applicable NAS timer indicated in table 10.3.2 for access via a satellite NG-RAN
cell."* The specified signal is this indication from the AMF. With nothing setting it, an SMF that reads it can
only fall back to configuration, which cannot distinguish a satellite cell from a terrestrial one on
the same AMF.

The consumer is [omec-project/smf#623](https://github.com/omec-project/smf/pull/623), which reads it
when resolving T3591.

## The narrower predicate is the point

`AmfUe.IsNtn()` already exists and answers "is this access non-terrestrial". Reusing it would be
wrong, and that is the whole substance of this change.

**NOTE 5 of table 10.3.2** names **NR(MEO)** and **NR(GEO)**, and no other access — table 10.3.1
says the same for the UE side in its NOTE 7. (Corrected: an earlier revision of this description and
of the code comments attributed that note to subclause 4.23.4, which carries only NOTE 1.) A LEO round
trip is tens of milliseconds — TS 23.501 NOTE 17 gives roughly 21 ms one way at 1200 km and 13 ms at
600 km — so the base values are conformant there, and extending them would delay every recovery on a
constellation that does not need it. `NR(OTHER_SAT)` is unnamed by that note and takes the base values
by the letter of the specification.

So `UsesExtendedNasSmTimers` is deliberately narrower than `IsNtn`, and a test pins that one is a
strict subset of the other:

```go
if ue.UsesExtendedNasSmTimers() && !ue.IsNtn() { ... }   // must never happen
leo := &AmfUe{RatType: models.RATTYPE_NR_LEO}
if !leo.IsNtn() || leo.UsesExtendedNasSmTimers() { ... } // LEO: NTN, but base timers
```

That relationship is pinned rather than assumed because deriving either predicate from the other is
the mistake worth preventing, and it is an easy one to make in a later cleanup.

## Where the orbit comes from

`ue.RatType`, upgraded at registration from the `RATInformation` the serving RAN advertised for the
TAC at NGSetup. That path already exists in `gmm/handler.go` and this change only reads its result.

## This is unexercised in every deployment I can reach, and that is worth saying plainly

**No RAN available to me advertises `RATInformation`**, so `ue.RatType` stays generic NR, the
indication stays false, and nothing changes. Checked rather than assumed:

- **gnbsim** contains no reference to `RATInformation` anywhere.
- **UERANSIM** builds `SupportedTAItem` with a TAC and a broadcast PLMN list only, and never
  populates `iE_Extensions` anywhere in the gNB. It does carry an orbit internally — a hardcoded
  `ratType = 4` (NR-GEO) in the RRC UE context — and logs `RAT type: NR-GEO (value=4)` for every UE,
  which reads exactly like a RAN advertising its orbit. That value never reaches the wire.

That last detail cost me a wrong conclusion before I read the source, so it is recorded here: a log
line that looks like confirmation was the opposite of it.

The mechanism is correct for a Rel-18 RAN and does nothing until one appears. Where nothing
advertises the IE, a deployment runs on configured timer values, which is what the SMF side already
supports. I would rather ship the conformant path and say it is dormant than derive the orbit from
something cheaper and be wrong for LEO.

## Sent only when true

The field is optional, and an SMF that reads it treats absence and false alike. An explicit false
would add a field to every session-create request on every deployment in order to say nothing.

## Tests

Seven RAT types across the predicate — MEO and GEO true, LEO, OTHER_SAT, NR, EUTRA and unset false —
plus the subset relationship above. Mutation-verified: substituting `IsNtn` for the predicate fails
the LEO case.

`go build ./...`, `go test ./context/... ./consumer/... ./gmm/... -race` and `golangci-lint run` are
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyNr6vp6JaxxzPyVcuHXTf


