### PR TITLE
fix(consumer): stop discarding the error models the client decoded

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -247,10 +247,9 @@ var SendCreateSubscription = func(ctx context.Context, nrfUri string, nrfSubscri
 				logger.ConsumerLog.Errorf("SendCreateSubscription response cannot close: %+v", resCloseErr)
 			}
 		}()
-		if res.Status != err.Error() {
-			logger.ConsumerLog.Errorf("SendCreateSubscription received error response: %s", res.Status)
-			return nrfSubData, problemDetails, err
-		}
+		// Logged for every error response now, not only for the ones the removed guard let through.
+		// The message was already true in both cases and the subscription failing is worth a line.
+		logger.ConsumerLog.Errorf("SendCreateSubscription received error response: %s", res.Status)
 		if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
 			problemDetails = &problem
 		} else {
@@ -297,9 +296,6 @@ var SendRemoveSubscription = func(ctx context.Context, subscriptionId string) (p
 				err = fmt.Errorf("RemoveSubscription's response body cannot close: %w", bodyCloseErr)
 			}
 		}()
-		if res.Status != err.Error() {
-			return problemDetails, err
-		}
 		if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
 			problemDetails = &problem
 		} else {

--- a/consumer/nf_management_test.go
+++ b/consumer/nf_management_test.go
@@ -36,7 +36,7 @@ func TestGetNfProfileUsesFqdnForHostnameRegistration(t *testing.T) {
 	}()
 
 	amfCtx := &amf_context.AMFContext{
-		NfId:         "amf-instance-id",
+		NfId:         testAmfInstanceID,
 		RegisterIPv4: "amf",
 		UriScheme:    models.URISCHEME_HTTP,
 		SBIPort:      29518,
@@ -85,7 +85,7 @@ func TestGetNfProfileUsesIpv4AddressForLiteralRegistration(t *testing.T) {
 	}()
 
 	amfCtx := &amf_context.AMFContext{
-		NfId:         "amf-instance-id",
+		NfId:         testAmfInstanceID,
 		RegisterIPv4: registerIPv4,
 		UriScheme:    models.URISCHEME_HTTP,
 		SBIPort:      29518,

--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -246,10 +246,12 @@ func SendCreateSmContextRequest(ctx context.Context, ue *amf_context.AmfUe, smCo
 			smContextRef = httpResponse.Header.Get("Location")
 		}
 	} else if httpResponse != nil {
-		if httpResponse.Status != err.Error() {
-			err1 = err
-			return response, smContextRef, errorResponse, problemDetail, err1
-		}
+		// The status carried by the response decides how to read the body. The error's message
+		// does not: the generated client replaces it with FormatErrorMessage(status, model) as soon
+		// as the body decodes, and that appends whatever a top-level Title or Detail holds. Any
+		// model with those fields -- ProblemDetails has both -- therefore produces a message that
+		// differs from the bare status, so comparing the two discarded exactly the responses that
+		// had been decoded successfully.
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503, 504:
 			if errResponse, ok := decodeErrorResponseBody[models.PostSmContexts400Response](httpResponse); ok {
@@ -260,11 +262,15 @@ func SendCreateSmContextRequest(ctx context.Context, ue *amf_context.AmfUe, smCo
 				err1 = err
 			}
 		case 411, 413, 415, 429:
-			if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
-				problemDetail = &problem
+			if problem, ok := problemDetailsFrom(err); ok {
+				problemDetail = problem
 			} else {
 				err1 = err
 			}
+		default:
+			// A status this switch does not name still failed. Returning neither a model nor an
+			// error would report the call as successful.
+			err1 = err
 		}
 	} else {
 		err1 = err
@@ -644,10 +650,6 @@ func SendUpdateSmContextRequest(ctx context.Context, smContext *amf_context.SmCo
 			return response, errorResponse, problemDetail, nil
 		}
 	} else if httpResponse != nil {
-		if httpResponse.Status != err.Error() {
-			err1 = err
-			return response, errorResponse, problemDetail, err1
-		}
 		switch httpResponse.StatusCode {
 		case 400, 403, 404, 500, 503:
 			if errResponse, ok := decodeErrorResponseBody[models.UpdateSmContext400Response](httpResponse); ok {
@@ -658,16 +660,55 @@ func SendUpdateSmContextRequest(ctx context.Context, smContext *amf_context.SmCo
 				err1 = err
 			}
 		case 411, 413, 415, 429:
-			if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
-				problemDetail = &problem
+			if problem, ok := problemDetailsFrom(err); ok {
+				problemDetail = problem
 			} else {
 				err1 = err
 			}
+		default:
+			// A status this switch does not name still failed. Returning neither a model nor an
+			// error would report the call as successful.
+			err1 = err
 		}
 	} else {
 		err1 = err
 	}
 	return response, errorResponse, problemDetail, err1
+}
+
+// problemDetailsFrom returns the problem the peer reported, whichever of the two shapes the
+// generated client decoded it into.
+//
+// The client chooses the model per status: 411 is decoded as models.ProblemDetails, while 413, 415
+// and 429 are decoded as models.ExtProblemDetails, which is the same object with one extra field.
+// Asking only for ProblemDetails therefore matched one status in four. That never showed, because
+// the comparison this function replaced meant the switch was not reached at all.
+//
+// RemoteError has no counterpart in ProblemDetails and is dropped. It reports which remote NF
+// produced the error, which the callers here do not use; everything the UE-facing paths read -
+// cause, title, detail, invalid parameters - is carried over.
+func problemDetailsFrom(err error) (*models.ProblemDetails, bool) {
+	if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
+		return &problem, true
+	}
+	if ext, ok := openapi.ErrorModel[models.ExtProblemDetails](err); ok {
+		return &models.ProblemDetails{
+			Type:                 ext.Type,
+			Title:                ext.Title,
+			Status:               ext.Status,
+			Detail:               ext.Detail,
+			Instance:             ext.Instance,
+			Cause:                ext.Cause,
+			InvalidParams:        ext.InvalidParams,
+			SupportedFeatures:    ext.SupportedFeatures,
+			AccessTokenError:     ext.AccessTokenError,
+			AccessTokenRequest:   ext.AccessTokenRequest,
+			NrfId:                ext.NrfId,
+			SupportedApiVersions: ext.SupportedApiVersions,
+			NoProfileMatchInfo:   ext.NoProfileMatchInfo,
+		}, true
+	}
+	return nil, false
 }
 
 // decodeErrorResponseBody decodes an error response body into T, reporting whether it

--- a/consumer/sm_context_test.go
+++ b/consumer/sm_context_test.go
@@ -24,6 +24,7 @@ import (
 const (
 	createSmContextPath = "/nsmf-pdusession/v1/sm-contexts"
 	updateSmContextPath = "/nsmf-pdusession/v1/sm-contexts/ctx-ref/modify"
+	testAmfInstanceID   = "amf-instance-id"
 )
 
 func TestSendCreateSmContextRequestIncludesRequestTypeAndN1Payload(t *testing.T) {
@@ -43,7 +44,7 @@ func TestSendCreateSmContextRequestIncludesRequestTypeAndN1Payload(t *testing.T)
 		self.SBIPort = originalSBIPort
 	}()
 
-	self.NfId = "amf-instance-id"
+	self.NfId = testAmfInstanceID
 	self.ServedGuamiList = []models.Guami{{
 		PlmnId: models.PlmnIdNid{Mcc: "001", Mnc: "01"},
 		AmfId:  "cafe00",
@@ -568,7 +569,7 @@ func TestSendCreateSmContextRequestRelaysSmfRejection(t *testing.T) {
 		self.SBIPort = originalSBIPort
 	}()
 
-	self.NfId = "amf-instance-id"
+	self.NfId = testAmfInstanceID
 	self.ServedGuamiList = []models.Guami{{
 		PlmnId: models.PlmnIdNid{Mcc: "001", Mnc: "01"},
 		AmfId:  "cafe00",
@@ -580,9 +581,11 @@ func TestSendCreateSmContextRequestRelaysSmfRejection(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		readMultipartRequestPartsByName(t, r, []string{"jsonData", "binaryDataN1SmMessage"})
 
-		// Title and Detail are populated on purpose. They sit nested under error, so
-		// FormatErrorMessage still finds no top-level Title and the consumer's
-		// `httpResponse.Status != err.Error()` guard does not trip.
+		// Title and Detail are populated on purpose, and they sit nested under error rather than
+		// at the top level. That used to matter for a second reason - it was why FormatErrorMessage
+		// left the message equal to the bare status, so the old status-versus-message guard did not
+		// trip on this path - and the guard is gone now. It still matters for what it asserts: the
+		// rejection the UE has to receive travels in the nested error object.
 		writeMultipartRejection(t, w, http.StatusForbidden, models.SmContextCreateError{
 			Error: models.ExtProblemDetails{
 				Title:  openapi.PtrString("DNN_DENIED"),
@@ -799,5 +802,88 @@ func TestSendUpdateSmContextRequestDecodesJsonRejection(t *testing.T) {
 	}
 	if cause := errorResponse.JsonData.Error.GetCause(); cause != "N1_SM_ERROR" {
 		t.Errorf("expected rejection cause %q, got %q", "N1_SM_ERROR", cause)
+	}
+}
+
+// TestSendCreateSmContextRequestSurfacesAProblemDetails covers the statuses whose body is a bare
+// ProblemDetails rather than the multipart rejection above.
+//
+// The generated client replaces its error string with FormatErrorMessage(status, model) as soon as
+// the body decodes, and FormatErrorMessage appends anything it finds in a top-level Title or Detail
+// field. ProblemDetails has both, so the formatted message never equals the bare status and the
+// `httpResponse.Status != err.Error()` comparison that used to gate the switch always failed --
+// which meant the 411, 413, 415 and 429 branches never ran and the SMF's stated reason was thrown
+// away in favour of a bare error. The condition held whenever a body decoded, which is exactly when
+// there was something worth keeping.
+func TestSendCreateSmContextRequestSurfacesAProblemDetails(t *testing.T) {
+	self := amfContext.AMF_Self()
+	originalNfID := self.NfId
+	originalServedGuamiList := append([]models.Guami(nil), self.ServedGuamiList...)
+	defer func() {
+		self.NfId = originalNfID
+		self.ServedGuamiList = originalServedGuamiList
+	}()
+
+	self.NfId = testAmfInstanceID
+	self.ServedGuamiList = []models.Guami{{
+		PlmnId: models.PlmnIdNid{Mcc: "001", Mnc: "01"},
+		AmfId:  "cafe00",
+	}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		readMultipartRequestPartsByName(t, r, []string{"jsonData"})
+
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		if err := json.NewEncoder(w).Encode(models.ProblemDetails{
+			Title:  openapi.PtrString("TOO_MANY_REQUESTS"),
+			Detail: openapi.PtrString("the SMF is shedding load"),
+			Cause:  openapi.PtrString("INSUFFICIENT_RESOURCES"),
+			Status: openapi.PtrInt32(http.StatusTooManyRequests),
+		}); err != nil {
+			t.Errorf("failed to write the problem details: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	ue := &amfContext.AmfUe{
+		ServingAMF: self,
+		Supi:       "imsi-001010000000001",
+		Tai: models.Tai{
+			PlmnId: models.PlmnId{Mcc: "001", Mnc: "01"},
+			Tac:    "000001",
+		},
+		Guti:     "00101cafe00000001",
+		TimeZone: "+00:00",
+	}
+
+	smContext := amfContext.NewSmContext(10)
+	smContext.SetSmfUri(server.URL)
+	smContext.SetSmfID("smf-test")
+	smContext.SetSnssai(models.Snssai{Sst: 1, Sd: openapi.PtrString("010203")})
+	smContext.SetDnn("internet")
+	smContext.SetAccessType(models.ACCESSTYPE__3_GPP_ACCESS)
+
+	response, smContextRef, errorResponse, problemDetail, err := SendCreateSmContextRequest(
+		context.Background(),
+		ue,
+		smContext,
+		models.REQUESTTYPE_INITIAL_REQUEST.Ptr(),
+		nil,
+	)
+	if problemDetail == nil {
+		t.Fatalf("the SMF's ProblemDetails was discarded; the caller got only err = %v", err)
+	}
+	if response != nil || smContextRef != "" {
+		t.Errorf("a rejected request must not produce a session: response %+v, ref %q", response, smContextRef)
+	}
+	if errorResponse != nil {
+		t.Errorf("this status carries a bare problem, not the multipart rejection: %+v", errorResponse)
+	}
+	if got := problemDetail.GetCause(); got != "INSUFFICIENT_RESOURCES" {
+		t.Errorf("cause = %q, want %q", got, "INSUFFICIENT_RESOURCES")
+	}
+	if got := problemDetail.GetTitle(); got != "TOO_MANY_REQUESTS" {
+		t.Errorf("title = %q, want %q", got, "TOO_MANY_REQUESTS")
 	}
 }

--- a/consumer/ue_authentication.go
+++ b/consumer/ue_authentication.go
@@ -79,9 +79,6 @@ func SendUEAuthenticationAuthenticateRequest(ctx context.Context, ue *amfContext
 	if err == nil {
 		return ueAuthenticationCtx, nil, nil
 	} else if httpResponse != nil {
-		if httpResponse.Status != err.Error() {
-			return nil, nil, err
-		}
 		if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
 			return nil, &problem, nil
 		}
@@ -131,9 +128,6 @@ func SendAuth5gAkaConfirmRequest(ctx context.Context, ue *amfContext.AmfUe, resS
 	if err == nil {
 		return confirmResult, nil, nil
 	} else if httpResponse != nil {
-		if httpResponse.Status != err.Error() {
-			return nil, nil, err
-		}
 		switch httpResponse.StatusCode {
 		case 400, 500:
 			if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
@@ -141,7 +135,9 @@ func SendAuth5gAkaConfirmRequest(ctx context.Context, ue *amfContext.AmfUe, resS
 			}
 			return nil, nil, err
 		}
-		return nil, nil, nil
+		// A status this switch does not name still failed, so it is reported rather than returned
+		// as a success with nothing in it.
+		return nil, nil, err
 	} else {
 		return nil, nil, openapi.ReportError("server no response")
 	}
@@ -185,10 +181,6 @@ func SendEapAuthConfirmRequest(ctx context.Context, ue *amfContext.AmfUe, eapMsg
 	if err == nil {
 		response = eapSessionRsp
 	} else if httpResponse != nil {
-		if httpResponse.Status != err.Error() {
-			err1 = err
-			return response, problemDetails, err1
-		}
 		switch httpResponse.StatusCode {
 		case 400, 500:
 			if problem, ok := openapi.ErrorModel[models.ProblemDetails](err); ok {
@@ -196,6 +188,8 @@ func SendEapAuthConfirmRequest(ctx context.Context, ue *amfContext.AmfUe, eapMsg
 			} else {
 				err1 = err
 			}
+		default:
+			err1 = err
 		}
 	} else {
 		err1 = openapi.ReportError("server no response")


### PR DESCRIPTION
## What

Removes the `httpResponse.Status != err.Error()` comparison from every consumer error path, and fixes the model-shape mismatch it was hiding.

## Why

The generated client sets its error string to the bare status, then **replaces it with `FormatErrorMessage(status, model)` as soon as the response body decodes**. `FormatErrorMessage` appends whatever it finds in a top-level `Title` or `Detail` field — by name, whether or not the field is set. `ProblemDetails` has both, so the formatted message never equals the bare status.

The consumers compared the two to decide whether to read the body. The comparison therefore failed **precisely when a body had been decoded successfully**, and the code returned early with a bare error, discarding the reason the peer had gone to the trouble of sending.

Seven sites share the shape:

| file | sites | model asked for |
|---|---|---|
| `consumer/sm_context.go` | 2 | `SmContextCreateError` / `SmContextUpdateError` via the wrapper, and `ProblemDetails` |
| `consumer/ue_authentication.go` | 3 | `ProblemDetails` |
| `consumer/nf_management.go` | 2 | `ProblemDetails` |

The five outside `sm_context.go` all decode `ProblemDetails`, so they were swallowed unconditionally: an AUSF or NRF that answered with a problem got that problem thrown away every time.

## The second defect, which the comparison was hiding

With the gate gone, the `411, 413, 415, 429` arm still dropped three statuses in four. It asks for `models.ProblemDetails`, but the client decodes **411 as `ProblemDetails` and 413, 415 and 429 as `ExtProblemDetails`** — the same object plus `RemoteError`. `problemDetailsFrom` accepts either shape and carries every field the callers read; `RemoteError` has no counterpart in `ProblemDetails` and is dropped deliberately.

A status named by no arm now surfaces the error rather than returning success with nothing in it.

## Tests

`TestSendCreateSmContextRequestSurfacesAProblemDetails` drives a 429 with a real `ProblemDetails` body through `SendCreateSmContextRequest` and asserts the cause and title arrive. It fails on `main` with:

```
the SMF's ProblemDetails was discarded; the caller got only err =
429 Too Many Requests %!s(*string=0x14000314100) (%!s(*string=0x14000314110))
```

which shows both halves at once: the message differs from the status, and the difference is the pointer-formatting defect in `FormatErrorMessage`. That one is separate and belongs in `omec-project/openapi`; fixing it there would make these messages legible but would **not** fix this, since a populated `Title` also differs from the status.

## Two notes on scope

`SendAuth5gAkaConfirmRequest` returned `(nil, nil, nil)` for a status its switch did not name. Its
only caller checks `err`, then `problemDetails`, then reads `response.AuthResult` — so that path
handed the caller a nil pointer to dereference. Returning the error closes that as well.

The `SendCreateSubscription` error log moved out of the removed guard rather than going with it, so
it now fires for every error response instead of only the ones the guard let through. The message
was already true in both cases; called out because it is a behaviour change beyond removing the
comparison.

Full suite green with `-race`, `golangci-lint` clean.

Follows the discussion on #790, where @gab-arrobo asked for this to be addressed.
