### PR TITLE
fix(context): five process-ending faults in UE-context handling

### DIFF
--- a/consumer/nsselection.go
+++ b/consumer/nsselection.go
@@ -61,7 +61,7 @@ func NSSelectionGetForRegistration(ctx context.Context, ue *amf_context.AmfUe, r
 	if localErr == nil {
 		ue.NetworkSliceInfo = res
 		for _, allowedNssai := range res.AllowedNssaiList {
-			ue.AllowedNssai[allowedNssai.AccessType] = allowedNssai.AllowedSnssaiList
+			ue.SetAllowedNssai(allowedNssai.AccessType, allowedNssai.AllowedSnssaiList)
 		}
 		ue.ConfiguredNssai = res.ConfiguredNssai
 	} else if httpResp != nil {

--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -267,11 +267,19 @@ func SDMGetSliceSelectionSubscriptionData(ctx context.Context, ue *amf_context.A
 	apiGetNSSAIRequest = apiGetNSSAIRequest.PlmnId(*plmnId)
 	nssai, httpResp, localErr := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAIExecute(apiGetNSSAIRequest)
 
-	// A nil body is not an error to the generated client: an empty or contentless
-	// response yields (nil, resp, nil), and ranging over it kills the process rather
-	// than this one registration. Seen in production -- the AMF aborted here during a
-	// registration burst and took every UE on five gNBs with it.
-	if localErr == nil && nssai != nil {
+	// Four outcomes have to be told apart, and only two of them were handled. A nil
+	// body is not an error to the generated client -- an empty or contentless response
+	// yields (nil, resp, nil) -- so ranging over the result killed the process rather
+	// than failing this one registration. Guarding only that range then sent the same
+	// case into the error branch below, where localErr.Error() dereferences a nil
+	// error and kills it just the same, one line further down.
+	if localErr == nil && nssai == nil {
+		// The subscriber has no slice-selection data. Nothing to add, and nothing
+		// wrong: leave SubscribedNssai as it is and report no error.
+		return problemDetails, err
+	}
+
+	if localErr == nil {
 		for _, defaultSnssai := range nssai.DefaultSingleNssais {
 			subscribedSnssai := models.SubscribedSnssai{
 				SubscribedSnssai: models.Snssai{

--- a/consumer/subscriber_data_management.go
+++ b/consumer/subscriber_data_management.go
@@ -266,7 +266,12 @@ func SDMGetSliceSelectionSubscriptionData(ctx context.Context, ue *amf_context.A
 	apiGetNSSAIRequest := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAI(ctx, ue.GetSupi())
 	apiGetNSSAIRequest = apiGetNSSAIRequest.PlmnId(*plmnId)
 	nssai, httpResp, localErr := client.SliceSelectionSubscriptionDataRetrievalAPI.GetNSSAIExecute(apiGetNSSAIRequest)
-	if localErr == nil {
+
+	// A nil body is not an error to the generated client: an empty or contentless
+	// response yields (nil, resp, nil), and ranging over it kills the process rather
+	// than this one registration. Seen in production -- the AMF aborted here during a
+	// registration burst and took every UE on five gNBs with it.
+	if localErr == nil && nssai != nil {
 		for _, defaultSnssai := range nssai.DefaultSingleNssais {
 			subscribedSnssai := models.SubscribedSnssai{
 				SubscribedSnssai: models.Snssai{

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -656,13 +656,13 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 	ue.Mutex.Lock()
 	oldRanUe := ue.RanUe[anType]
 	if oldRanUe == ranUe {
-		ranUe.AmfUe = ue
+		ranUe.SetAmfUe(ue)
 		ue.Mutex.Unlock()
 		ue.updateAttachedRanUeLogs(ranUe)
 		return
 	}
 	ue.RanUe[anType] = ranUe
-	ranUe.AmfUe = ue
+	ranUe.SetAmfUe(ue)
 	ue.Mutex.Unlock()
 
 	if oldRanUe != nil {
@@ -674,7 +674,7 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 
 			if oldRanUe.AmfUe == ue && ue.RanUe[anType] == newRanUe {
 				logger.ContextLog.Infof("detached UeContext from OldRanUe %v", oldRanUe.AmfUeNgapId)
-				oldRanUe.AmfUe = nil
+				oldRanUe.DetachAmfUe()
 			}
 		}(oldRanUe, ranUe, anType)
 	}

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -78,7 +78,13 @@ type AmfUe struct {
 	// state) so an accessor can never self-deadlock against a Mutex holder.
 	identityMu sync.RWMutex `json:"-"`
 	/* the AMF which serving this AmfUe now */
-	ServingAMF *AMFContext `json:"servingAMF,omitempty"` // never nil
+	// Not persisted. It points at the process-wide AMF context, which init() sets on
+	// every UE, so serialising it wrote a copy of the whole singleton -- RanUePool,
+	// NfService, the subscription tables -- into each UE document, and restoring one
+	// decoded straight back into that live singleton: two restores at once are
+	// "fatal error: concurrent map writes", and one alone silently overwrites the
+	// running AMF's own state with a snapshot from whenever that UE was stored.
+	ServingAMF *AMFContext `json:"-"` // never nil
 
 	/* Gmm State */
 	State map[models.AccessType]*fsm.State `json:"-"`

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -226,6 +226,18 @@ type AmfUe struct {
 }
 
 func (ue *AmfUe) MarshalJSON() ([]byte, error) {
+	// The encoder walks maps that other goroutines write while holding this very
+	// mutex -- RanUe is written by AttachRanUe and DetachRanUe -- so marshalling them
+	// unguarded ends the process with "concurrent map iteration and map write", which
+	// takes every UE on this AMF with it. Being on the UE's own EventChannel
+	// goroutine is not protection: the writers run on other goroutines.
+	//
+	// Safe to take here: no caller holds it. StoreContextInDB is reached from the gmm
+	// and ngap handlers, context/db.go's own locking is a separate package-level
+	// mutex, and nothing in this function calls back into a method that locks.
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
 	type Alias AmfUe
 	stateVal := make(map[models.AccessType]string)
 	smCtxListVal := make(map[string]SmContext)

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -669,12 +669,16 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 	oldRanUe := ue.RanUe[anType]
 	if oldRanUe == ranUe {
 		ranUe.SetAmfUe(ue)
-		ue.Mutex.Unlock()
 		ue.updateAttachedRanUeLogs(ranUe)
+		ue.Mutex.Unlock()
+
 		return
 	}
 	ue.RanUe[anType] = ranUe
 	ranUe.SetAmfUe(ue)
+	// Under the same lock as the RanUe map: the loggers carry the NGAP id of the RanUe
+	// just attached, and methods holding this lock log through them.
+	ue.updateAttachedRanUeLogs(ranUe)
 	ue.Mutex.Unlock()
 
 	if oldRanUe != nil {
@@ -684,14 +688,12 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 			ue.Mutex.Lock()
 			defer ue.Mutex.Unlock()
 
-			if oldRanUe.AmfUe == ue && ue.RanUe[anType] == newRanUe {
+			if oldRanUe.GetAmfUe() == ue && ue.RanUe[anType] == newRanUe {
 				logger.ContextLog.Infof("detached UeContext from OldRanUe %v", oldRanUe.AmfUeNgapId)
 				oldRanUe.DetachAmfUe()
 			}
 		}(oldRanUe, ranUe, anType)
 	}
-
-	ue.updateAttachedRanUeLogs(ranUe)
 }
 
 func (ue *AmfUe) updateAttachedRanUeLogs(ranUe *RanUe) {
@@ -973,6 +975,9 @@ func (ue *AmfUe) ClearRegistrationRequestData(accessType models.AccessType) {
 
 // this method called when we are reusing the same uecontext during the registration procedure
 func (ue *AmfUe) ClearRegistrationData() {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
 	// Allowed Nssai should be cleared first as it is a new Registration
 	ue.SubscribedNssai = nil
 	ue.AllowedNssai = make(map[models.AccessType][]models.AllowedSnssai)
@@ -984,7 +989,84 @@ func (ue *AmfUe) ClearRegistrationData() {
 	})
 }
 
+// The maps below are serialised whenever a UE context is persisted, and the
+// encoder reads them from whichever goroutine calls StoreContextInDB. Writing them
+// from another goroutine at the same time is a fatal runtime error -- "concurrent
+// map read and map write" -- which ends the process and every UE on this AMF, not
+// just the procedure that was running. Both sides therefore go through ue.Mutex:
+// MarshalJSON takes it to read, and these take it to write.
+//
+// They are deliberately small: no SBI call or channel send belongs inside them.
+
+// SetAllowedNssai replaces the allowed NSSAI for one access type.
+func (ue *AmfUe) SetAllowedNssai(anType models.AccessType, allowed []models.AllowedSnssai) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.AllowedNssai[anType] = allowed
+}
+
+// AppendAllowedNssai adds one entry to the allowed NSSAI of an access type.
+func (ue *AmfUe) AppendAllowedNssai(anType models.AccessType, allowed models.AllowedSnssai) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.AllowedNssai[anType] = append(ue.AllowedNssai[anType], allowed)
+}
+
+// SetReleaseCause records why an access is being released, or clears it with nil.
+func (ue *AmfUe) SetReleaseCause(anType models.AccessType, cause *CauseAll) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.ReleaseCause[anType] = cause
+}
+
+// SetRegistrationArea replaces the registration area of an access type.
+func (ue *AmfUe) SetRegistrationArea(anType models.AccessType, area []models.Tai) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.RegistrationArea[anType] = area
+}
+
+// AppendRegistrationArea adds one TAI to the registration area of an access type.
+func (ue *AmfUe) AppendRegistrationArea(anType models.AccessType, tai models.Tai) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.RegistrationArea[anType] = append(ue.RegistrationArea[anType], tai)
+}
+
+// RegistrationAreaLen reports how many TAIs an access type has, for callers that
+// only need the count and would otherwise read the map unguarded.
+func (ue *AmfUe) RegistrationAreaLen(anType models.AccessType) int {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	return len(ue.RegistrationArea[anType])
+}
+
+// SetEventSubscription stores an event-exposure subscription.
+func (ue *AmfUe) SetEventSubscription(id string, subscription *AmfUeEventSubscription) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	ue.EventSubscriptionsInfo[id] = subscription
+}
+
+// DeleteEventSubscription removes an event-exposure subscription.
+func (ue *AmfUe) DeleteEventSubscription(id string) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	delete(ue.EventSubscriptionsInfo, id)
+}
+
 func (ue *AmfUe) SetOnGoing(anType models.AccessType, onGoing *OnGoingProcedureWithPrio) {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
 	prevOnGoing := ue.OnGoing[anType]
 	ue.OnGoing[anType] = onGoing
 	ue.GmmLog.Debugf("OnGoing[%s]->[%s] PPI[%d]->[%d]", prevOnGoing.Procedure, onGoing.Procedure,
@@ -1183,7 +1265,7 @@ func (ue *AmfUe) CopyDataFromUeContextModel(ueContext models.UeContext) {
 					allowedSnssai := models.AllowedSnssai{
 						AllowedSnssai: snssai,
 					}
-					ue.AllowedNssai[mmContext.AccessType] = append(ue.AllowedNssai[mmContext.AccessType], allowedSnssai)
+					ue.AppendAllowedNssai(mmContext.AccessType, allowedSnssai)
 				}
 			}
 		}

--- a/context/amf_ue_concurrency_test.go
+++ b/context/amf_ue_concurrency_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// Persisting a UE context marshals six maps that other goroutines write while the
+// UE is being served: RanUe, OnGoing, RegistrationArea, AllowedNssai, ReleaseCause
+// and EventSubscriptionsInfo. A write landing during that marshal is a fatal runtime
+// error -- "concurrent map read and map write" -- which ends the process and every
+// UE on this AMF, not the one procedure that happened to be running.
+//
+// Both sides go through ue.Mutex, so this drives every writer against a marshalling
+// goroutine. Under -race it fails if any of them stops taking the lock.
+func TestStoringAContextWhileEveryMapIsWritten(t *testing.T) {
+	ue := &AmfUe{}
+	ue.init()
+	ue.Supi = "imsi-208930100007487"
+
+	ran := &AmfRan{AnType: models.ACCESSTYPE__3_GPP_ACCESS, GnbId: "208:93:00100c"}
+	anType := models.ACCESSTYPE__3_GPP_ACCESS
+
+	const rounds = 2000
+
+	writers := []func(i int){
+		func(i int) { ue.SetAllowedNssai(anType, []models.AllowedSnssai{{}}) },
+		func(i int) { ue.AppendAllowedNssai(anType, models.AllowedSnssai{}) },
+		func(i int) { ue.SetOnGoing(anType, &OnGoingProcedureWithPrio{Procedure: OnGoingProcedureNothing}) },
+		func(i int) { ue.SetReleaseCause(anType, &CauseAll{}) },
+		func(i int) { ue.SetRegistrationArea(anType, nil) },
+		func(i int) { ue.AppendRegistrationArea(anType, models.Tai{}) },
+		func(i int) { ue.SetEventSubscription("sub", &AmfUeEventSubscription{}) },
+		func(i int) { ue.DeleteEventSubscription("sub") },
+		func(i int) {
+			ranUe := &RanUe{RanUeNgapId: int64(i), AmfUeNgapId: int64(i), Ran: ran}
+			ue.AttachRanUe(ranUe)
+		},
+		func(i int) { ue.DetachRanUe(anType) },
+		func(i int) { _ = ue.RegistrationAreaLen(anType) },
+	}
+
+	var wg sync.WaitGroup
+
+	for _, write := range writers {
+		wg.Add(1)
+
+		go func(write func(int)) {
+			defer wg.Done()
+
+			for i := range rounds {
+				write(i)
+			}
+		}(write)
+	}
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range rounds {
+			if _, err := sonic.Marshal(ue); err != nil {
+				t.Errorf("storing a context must not fail: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/context/amf_ue_concurrency_test.go
+++ b/context/amf_ue_concurrency_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/omec-project/openapi/v2/models"
 )
 
+// testSupi is the subscriber every test in this package builds its UE around.
+const testSupi = "imsi-208930100007487"
+
 // Persisting a UE context marshals six maps that other goroutines write while the
 // UE is being served: RanUe, OnGoing, RegistrationArea, AllowedNssai, ReleaseCause
 // and EventSubscriptionsInfo. A write landing during that marshal is a fatal runtime
@@ -23,7 +26,7 @@ import (
 func TestStoringAContextWhileEveryMapIsWritten(t *testing.T) {
 	ue := &AmfUe{}
 	ue.init()
-	ue.Supi = "imsi-208930100007487"
+	ue.Supi = testSupi
 
 	ran := &AmfRan{AnType: models.ACCESSTYPE__3_GPP_ACCESS, GnbId: "208:93:00100c"}
 	anType := models.ACCESSTYPE__3_GPP_ACCESS

--- a/context/amf_ue_marshal_test.go
+++ b/context/amf_ue_marshal_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// Persisting a UE context marshals maps that other goroutines write: AttachRanUe and
+// DetachRanUe hold ue.Mutex while changing ue.RanUe, and the encoder iterates it. If
+// the marshal does not take the same lock, the runtime aborts the whole process with
+// "concurrent map iteration and map write" -- not one failed store, every UE on this
+// AMF. Under -race this test fails if MarshalJSON stops holding the lock.
+func TestStoringAContextWhileItsRanUeChanges(t *testing.T) {
+	ue := &AmfUe{}
+	ue.init()
+	ue.Supi = "imsi-208930100007487"
+
+	ran := &AmfRan{AnType: models.ACCESSTYPE__3_GPP_ACCESS, GnbId: "208:93:00100c"}
+
+	const rounds = 3000
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range rounds {
+			// What AttachRanUe and DetachRanUe do to the map, under the same lock.
+			ranUe := &RanUe{RanUeNgapId: int64(i), AmfUeNgapId: int64(i), Ran: ran}
+
+			ue.Mutex.Lock()
+			ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] = ranUe
+			ue.Mutex.Unlock()
+
+			ue.Mutex.Lock()
+			delete(ue.RanUe, models.ACCESSTYPE__3_GPP_ACCESS)
+			ue.Mutex.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range rounds {
+			if _, err := sonic.Marshal(ue); err != nil {
+				t.Errorf("marshalling a context must not fail: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/context/amf_ue_marshal_test.go
+++ b/context/amf_ue_marshal_test.go
@@ -20,7 +20,7 @@ import (
 func TestStoringAContextWhileItsRanUeChanges(t *testing.T) {
 	ue := &AmfUe{}
 	ue.init()
-	ue.Supi = "imsi-208930100007487"
+	ue.Supi = testSupi
 
 	ran := &AmfRan{AnType: models.ACCESSTYPE__3_GPP_ACCESS, GnbId: "208:93:00100c"}
 

--- a/context/amf_ue_serving_amf_test.go
+++ b/context/amf_ue_serving_amf_test.go
@@ -19,7 +19,7 @@ import (
 func TestAStoredContextDoesNotCarryTheAmf(t *testing.T) {
 	ue := &AmfUe{}
 	ue.init()
-	ue.Supi = "imsi-208930100007487"
+	ue.Supi = testSupi
 
 	stored, err := sonic.Marshal(ue)
 	if err != nil {

--- a/context/amf_ue_serving_amf_test.go
+++ b/context/amf_ue_serving_amf_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+// init() points every UE at the process-wide AMF context. Persisting that pointer
+// wrote the whole singleton into each UE document, and restoring a UE decoded back
+// into the live one -- so a restore overwrote the running AMF's state, and two at
+// once were "fatal error: concurrent map writes" with no recovery.
+func TestAStoredContextDoesNotCarryTheAmf(t *testing.T) {
+	ue := &AmfUe{}
+	ue.init()
+	ue.Supi = "imsi-208930100007487"
+
+	stored, err := sonic.Marshal(ue)
+	if err != nil {
+		t.Fatalf("storing a context must not fail: %v", err)
+	}
+
+	if strings.Contains(string(stored), "servingAMF") {
+		t.Error("the stored context carries the AMF singleton; restoring it will write the running AMF's own state")
+	}
+}
+
+// A document written before the field was dropped still carries servingAMF. Restoring
+// it must leave the running AMF alone rather than decode into it.
+func TestRestoringAnOldDocumentLeavesTheRunningAmfAlone(t *testing.T) {
+	self := AMF_Self()
+	self.Name = "the running AMF"
+
+	ue := &AmfUe{}
+	ue.init()
+
+	old := `{"supi":"imsi-208930100007487","servingAMF":{"Name":"a stored snapshot"}}`
+	if err := sonic.Unmarshal([]byte(old), ue); err != nil {
+		t.Fatalf("restoring a context must not fail: %v", err)
+	}
+
+	if self.Name != "the running AMF" {
+		t.Errorf("restoring a UE overwrote the running AMF: Name = %q", self.Name)
+	}
+}
+
+// Restores run on the NGAP reader goroutines, so several land at once. Under -race
+// this fails if the decoder can still reach a shared map.
+func TestConcurrentRestoresDoNotShareAMap(t *testing.T) {
+	const restores = 400
+
+	doc := []byte(`{"supi":"imsi-208930100007487","servingAMF":{"Name":"a stored snapshot",` +
+		`"PlmnSupportList":[{"plmnId":{"mcc":"208","mnc":"93"}}]}}`)
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range restores {
+				ue := &AmfUe{}
+				ue.init()
+
+				if err := sonic.Unmarshal(doc, ue); err != nil {
+					t.Errorf("restoring a context must not fail: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/context/common_function.go
+++ b/context/common_function.go
@@ -73,7 +73,7 @@ func AttachSourceUeTargetUe(sourceUe, targetUe *RanUe) {
 		logger.ContextLog.Error("AmfUe is Nil")
 		return
 	}
-	targetUe.AmfUe = amfUe
+	targetUe.SetAmfUe(amfUe)
 	targetUe.SourceUe = sourceUe
 	sourceUe.TargetUe = targetUe
 }

--- a/context/context.go
+++ b/context/context.go
@@ -182,8 +182,8 @@ func (context *AMFContext) ReAllocateGutiToUe(ue *AmfUe) {
 
 func (context *AMFContext) AllocateRegistrationArea(ue *AmfUe, anType models.AccessType) {
 	// clear the previous registration area if need
-	if len(ue.RegistrationArea[anType]) > 0 {
-		ue.RegistrationArea[anType] = nil
+	if ue.RegistrationAreaLen(anType) > 0 {
+		ue.SetRegistrationArea(anType, nil)
 	}
 
 	// allocate a new tai list as a registration area to ue
@@ -201,7 +201,7 @@ func (context *AMFContext) AllocateRegistrationArea(ue *AmfUe, anType models.Acc
 	}
 	for _, supportTai := range taiList {
 		if reflect.DeepEqual(supportTai, ue.Tai) {
-			ue.RegistrationArea[anType] = append(ue.RegistrationArea[anType], supportTai)
+			ue.AppendRegistrationArea(anType, supportTai)
 			break
 		}
 	}

--- a/context/db.go
+++ b/context/db.go
@@ -225,7 +225,7 @@ func DbFetch(collName string, filter bson.M) *AmfUe {
 	dbMutex.Lock()
 	defer dbMutex.Unlock()
 
-	ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].AmfUe = ue
+	ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].SetAmfUe(ue)
 	AMF_Self().RanUePool.Store(ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS].AmfUeNgapId, ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS])
 	AMF_Self().UePool.Store(ue.Supi, ue)
 	ue.EventChannel = nil

--- a/context/ran_ue.go
+++ b/context/ran_ue.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/mohae/deepcopy"
@@ -55,8 +56,12 @@ type RanUe struct {
 	LastActTime       *time.Time `json:"-"`
 
 	/* Related Context*/
-	AmfUe *AmfUe `json:"-"`
-	Ran   *AmfRan
+	// AmfUe is cleared from other goroutines (Remove, DetachAmfUe) while the NGAP
+	// read loop is still dispatching messages for this RanUe, so it is guarded by
+	// amfUeMu and must be reached through GetAmfUe/SetAmfUe rather than directly.
+	AmfUe   *AmfUe `json:"-"`
+	amfUeMu sync.RWMutex
+	Ran     *AmfRan
 
 	/* Routing ID */
 	RoutingID string
@@ -92,15 +97,12 @@ func (ranUe *RanUe) Remove() error {
 	if ran == nil {
 		return fmt.Errorf("RanUe not found in Ran")
 	}
-	if ranUe.AmfUe != nil {
-		amfUe := ranUe.AmfUe
+	if amfUe := ranUe.GetAmfUe(); amfUe != nil {
 		amfUe.Mutex.Lock()
 		if amfUe.RanUe[ran.AnType] == ranUe {
 			delete(amfUe.RanUe, ran.AnType)
 		}
-		if ranUe.AmfUe == amfUe {
-			ranUe.AmfUe = nil
-		}
+		ranUe.DetachAmfUeIf(amfUe)
 		amfUe.Mutex.Unlock()
 	}
 
@@ -119,8 +121,58 @@ func (ranUe *RanUe) Remove() error {
 	return nil
 }
 
+// GetAmfUe returns the AmfUe this RanUe belongs to, or nil once the association has
+// been dropped. Callers must keep the returned pointer instead of re-reading the
+// field. Every re-read is a fresh chance to observe the nil that Remove writes, and
+// the NGAP read loop that reads it runs with no recover(), so one badly-timed re-read
+// ends the whole AMF process rather than one procedure.
+func (ranUe *RanUe) GetAmfUe() *AmfUe {
+	if ranUe == nil {
+		return nil
+	}
+
+	ranUe.amfUeMu.RLock()
+	defer ranUe.amfUeMu.RUnlock()
+
+	return ranUe.AmfUe
+}
+
+// SetAmfUe associates this RanUe with amfUe.
+func (ranUe *RanUe) SetAmfUe(amfUe *AmfUe) {
+	if ranUe == nil {
+		return
+	}
+
+	ranUe.amfUeMu.Lock()
+	defer ranUe.amfUeMu.Unlock()
+
+	ranUe.AmfUe = amfUe
+}
+
 func (ranUe *RanUe) DetachAmfUe() {
+	if ranUe == nil {
+		return
+	}
+
+	ranUe.amfUeMu.Lock()
+	defer ranUe.amfUeMu.Unlock()
+
 	ranUe.AmfUe = nil
+}
+
+// DetachAmfUeIf drops the association only while it still points at amfUe, so a
+// release that overlaps a re-attach to a different context cannot undo the newer one.
+func (ranUe *RanUe) DetachAmfUeIf(amfUe *AmfUe) {
+	if ranUe == nil {
+		return
+	}
+
+	ranUe.amfUeMu.Lock()
+	defer ranUe.amfUeMu.Unlock()
+
+	if ranUe.AmfUe == amfUe {
+		ranUe.AmfUe = nil
+	}
 }
 
 func (ranUe *RanUe) SwitchToRan(newRan *AmfRan, ranUeNgapId int64) error {

--- a/context/ran_ue_amfue_test.go
+++ b/context/ran_ue_amfue_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"sync"
+	"testing"
+)
+
+// A UE context release runs on a different goroutine from the NGAP reader, so the
+// association can be dropped between a reader's nil check and its use of the pointer.
+// The reader is the connection's only goroutine and it has no recover(), so observing
+// that nil ends the whole AMF process rather than one procedure -- every UE on every
+// gNB goes with it. Run under -race, this fails if the field is reached directly.
+func TestTheAssociationCanBeDroppedWhileReadersHoldIt(t *testing.T) {
+	ranUe := &RanUe{}
+	amfUe := &AmfUe{Supi: "imsi-208930100007487"}
+	ranUe.SetAmfUe(amfUe)
+
+	const rounds = 5000
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range rounds {
+			if i%2 == 0 {
+				ranUe.DetachAmfUe()
+				continue
+			}
+
+			ranUe.SetAmfUe(amfUe)
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range rounds {
+			// The shape every reader must use: read the association once, then work
+			// from that pointer, so a release cannot turn it nil mid-procedure.
+			if held := ranUe.GetAmfUe(); held != nil {
+				_ = held.Supi
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// Release must not undo a newer association, which is why the clear is conditional.
+func TestDetachAmfUeIfLeavesANewerAssociationAlone(t *testing.T) {
+	ranUe := &RanUe{}
+	first := &AmfUe{Supi: "imsi-208930100007487"}
+	second := &AmfUe{Supi: "imsi-208930100007488"}
+
+	ranUe.SetAmfUe(first)
+	ranUe.SetAmfUe(second)
+
+	ranUe.DetachAmfUeIf(first)
+
+	if held := ranUe.GetAmfUe(); held != second {
+		t.Errorf("association = %v, want the newer context %q", held, second.Supi)
+	}
+
+	ranUe.DetachAmfUeIf(second)
+
+	if held := ranUe.GetAmfUe(); held != nil {
+		t.Errorf("association = %v, want nil after releasing the context it holds", held)
+	}
+}
+
+// FetchRanUeContext can hand back a nil RanUe, and callers read the association from
+// it before checking anything else.
+func TestGetAmfUeOnANilRanUe(t *testing.T) {
+	var ranUe *RanUe
+
+	if held := ranUe.GetAmfUe(); held != nil {
+		t.Errorf("GetAmfUe() = %v, want nil", held)
+	}
+}

--- a/context/ran_ue_amfue_test.go
+++ b/context/ran_ue_amfue_test.go
@@ -16,7 +16,7 @@ import (
 // gNB goes with it. Run under -race, this fails if the field is reached directly.
 func TestTheAssociationCanBeDroppedWhileReadersHoldIt(t *testing.T) {
 	ranUe := &RanUe{}
-	amfUe := &AmfUe{Supi: "imsi-208930100007487"}
+	amfUe := &AmfUe{Supi: testSupi}
 	ranUe.SetAmfUe(amfUe)
 
 	const rounds = 5000
@@ -58,7 +58,7 @@ func TestTheAssociationCanBeDroppedWhileReadersHoldIt(t *testing.T) {
 // Release must not undo a newer association, which is why the clear is conditional.
 func TestDetachAmfUeIfLeavesANewerAssociationAlone(t *testing.T) {
 	ranUe := &RanUe{}
-	first := &AmfUe{Supi: "imsi-208930100007487"}
+	first := &AmfUe{Supi: testSupi}
 	second := &AmfUe{Supi: "imsi-208930100007488"}
 
 	ranUe.SetAmfUe(first)

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1630,7 +1630,7 @@ func handleRequestedNssai(ctx ctxt.Context, ue *context.AmfUe, registrationReque
 					allowedSnssai := models.AllowedSnssai{
 						AllowedSnssai: snssai.GetSubscribedSnssai(),
 					}
-					ue.AllowedNssai[anType] = append(ue.AllowedNssai[anType], allowedSnssai)
+					ue.AppendAllowedNssai(anType, allowedSnssai)
 				}
 			}
 		}
@@ -1643,7 +1643,7 @@ func rebuildAllowedNssaiFromRequested(
 	anType models.AccessType,
 	requestedNssai []models.MappingOfSnssai,
 ) bool {
-	ue.AllowedNssai[anType] = nil
+	ue.SetAllowedNssai(anType, nil)
 
 	for _, requestedSnssai := range requestedNssai {
 		if !ue.InSubscribedNssai(&requestedSnssai.ServingSnssai) {
@@ -1658,7 +1658,7 @@ func rebuildAllowedNssaiFromRequested(
 			MappedHomeSnssai: &requestedSnssai.HomeSnssai,
 		}
 		if !ue.InAllowedNssai(allowedSnssai.AllowedSnssai, anType) {
-			ue.AllowedNssai[anType] = append(ue.AllowedNssai[anType], allowedSnssai)
+			ue.AppendAllowedNssai(anType, allowedSnssai)
 		}
 	}
 

--- a/nas/handler.go
+++ b/nas/handler.go
@@ -30,14 +30,20 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 		return
 	}
 
-	if ue.AmfUe == nil {
-		ue.AmfUe = nas_security.FetchUeContextWithMobileIdentity(nasPdu)
-		if ue.AmfUe == nil {
-			ue.AmfUe = amfSelf.NewAmfUe("")
+	if ue.GetAmfUe() == nil {
+		// Read the association once and work from that pointer. Re-reading it is what
+		// makes this path fatal rather than merely wrong: a release running on another
+		// goroutine clears it, and nothing here recovers from a nil dereference.
+		amfUe := nas_security.FetchUeContextWithMobileIdentity(nasPdu)
+		ue.SetAmfUe(amfUe)
+
+		if amfUe == nil {
+			amfUe = amfSelf.NewAmfUe("")
+			ue.SetAmfUe(amfUe)
 		} else {
 			if amfSelf.EnableSctpLb && amfSelf.EnableDbStore {
 				/* checking the guti-ue belongs to this amf instance */
-				id, err := amfSelf.Drsm.FindOwnerInt32ID(ue.AmfUe.GetTmsi())
+				id, err := amfSelf.Drsm.FindOwnerInt32ID(amfUe.GetTmsi())
 				if err != nil {
 					logger.NasLog.Errorf("error checking guti-ue: %v", err)
 				}
@@ -50,13 +56,7 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 					rsp.RedirectId = id.PodIp
 					rsp.GnbId = ue.Ran.GnbId
 					rsp.Msg = ue.SctplbMsg
-					if ue.AmfUe != nil {
-						ue.AmfUe.Remove()
-					} else {
-						if err := ue.Remove(); err != nil {
-							logger.NasLog.Errorf("error removing ue: %v", err)
-						}
-					}
+					amfUe.Remove()
 					ue.Ran.Amf2RanMsgChan <- rsp
 					return
 				}
@@ -71,16 +71,16 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 		if amfSelf.EnableSctpLb {
 			ue.Ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
 		}
-		ue.AmfUe.AttachRanUe(ue)
+		amfUe.AttachRanUe(ue)
 
-		ue.AmfUe.Mutex.Lock()
-		if ue.AmfUe.EventChannel == nil {
-			ue.AmfUe.EventChannel = ue.AmfUe.NewEventChannel()
-			ue.AmfUe.EventChannel.UpdateNasHandler(DispatchMsg)
-			go ue.AmfUe.EventChannel.Start(ctx)
+		amfUe.Mutex.Lock()
+		if amfUe.EventChannel == nil {
+			amfUe.EventChannel = amfUe.NewEventChannel()
+			amfUe.EventChannel.UpdateNasHandler(DispatchMsg)
+			go amfUe.EventChannel.Start(ctx)
 		}
-		ue.AmfUe.EventChannel.UpdateNasHandler(DispatchMsg)
-		ue.AmfUe.Mutex.Unlock()
+		amfUe.EventChannel.UpdateNasHandler(DispatchMsg)
+		amfUe.Mutex.Unlock()
 
 		nasMsg := context.NasMsg{
 			Context:       ctx,
@@ -88,7 +88,7 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 			NasMsg:        nasPdu,
 			ProcedureCode: procedureCode,
 		}
-		ue.AmfUe.EventChannel.SubmitMessage(nasMsg)
+		amfUe.EventChannel.SubmitMessage(nasMsg)
 
 		return
 	}

--- a/nas/handler.go
+++ b/nas/handler.go
@@ -30,11 +30,13 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 		return
 	}
 
-	if ue.GetAmfUe() == nil {
-		// Read the association once and work from that pointer. Re-reading it is what
-		// makes this path fatal rather than merely wrong: a release running on another
-		// goroutine clears it, and nothing here recovers from a nil dereference.
-		amfUe := nas_security.FetchUeContextWithMobileIdentity(nasPdu)
+	// Read the association once and work from that pointer for the rest of the
+	// function. Re-reading it is what makes this path fatal rather than merely wrong:
+	// a release running on another goroutine clears it, and nothing here recovers from
+	// a nil dereference.
+	amfUe := ue.GetAmfUe()
+	if amfUe == nil {
+		amfUe = nas_security.FetchUeContextWithMobileIdentity(nasPdu)
 		ue.SetAmfUe(amfUe)
 
 		if amfUe == nil {
@@ -96,13 +98,13 @@ func HandleNAS(ctx ctxt.Context, ue *context.RanUe, procedureCode int64, nasPdu 
 		ue.Ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
 	}
 
-	msg, err := nas_security.Decode(ue.AmfUe, ue.Ran.AnType, nasPdu)
+	msg, err := nas_security.Decode(amfUe, ue.Ran.AnType, nasPdu)
 	if err != nil {
-		ue.AmfUe.NASLog.Errorln(err)
+		amfUe.NASLog.Errorln(err)
 		return
 	}
-	if err := Dispatch(ctx, ue.AmfUe, ue.Ran.AnType, procedureCode, msg); err != nil {
-		ue.AmfUe.NASLog.Errorf("handle NAS Error: %v", err)
+	if err := Dispatch(ctx, amfUe, ue.Ran.AnType, procedureCode, msg); err != nil {
+		amfUe.NASLog.Errorf("handle NAS Error: %v", err)
 	}
 }
 

--- a/ngap/dispatcher.go
+++ b/ngap/dispatcher.go
@@ -99,8 +99,8 @@ func DispatchLb(ctx ctxt.Context, sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2
 				copy(rsp.Msg, sctplbMsg.Msg)
 				ran.Amf2RanMsgChan = Amf2RanMsgChan
 				ran.Amf2RanMsgChan <- rsp
-				if ranUe != nil && ranUe.AmfUe != nil {
-					ranUe.AmfUe.Remove()
+				if amfUe := ranUe.GetAmfUe(); amfUe != nil {
+					amfUe.Remove()
 				}
 				if ranUe != nil {
 					if err := ranUe.Remove(); err != nil {
@@ -115,17 +115,17 @@ func DispatchLb(ctx ctxt.Context, sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2
 	}
 
 	/* uecontext is found, submit the message to transaction queue*/
-	if ranUe != nil && ranUe.AmfUe != nil {
-		ranUe.AmfUe.SetEventChannel(ctx, NgapMsgHandler)
-		// ranUe.AmfUe.TxLog.Infoln("Uecontext found. queuing ngap message to uechannel")
-		ranUe.AmfUe.EventChannel.UpdateNgapHandler(NgapMsgHandler)
+	if amfUe := ranUe.GetAmfUe(); amfUe != nil {
+		amfUe.SetEventChannel(ctx, NgapMsgHandler)
+		// amfUe.TxLog.Infoln("Uecontext found. queuing ngap message to uechannel")
+		amfUe.EventChannel.UpdateNgapHandler(NgapMsgHandler)
 		ngapMsg := context.NgapMsg{
 			Ran:       ran,
 			NgapMsg:   pdu,
 			SctplbMsg: sctplbMsg,
 		}
 
-		ranUe.AmfUe.EventChannel.SubmitMessage(ngapMsg)
+		amfUe.EventChannel.SubmitMessage(ngapMsg)
 	} else {
 		go DispatchNgapMsg(ctx, ran, pdu, sctplbMsg)
 	}
@@ -171,23 +171,26 @@ func Dispatch(conn net.Conn, msg []byte) {
 	ranUe, _ := FetchRanUeContext(ran, pdu)
 
 	/* uecontext is found, submit the message to transaction queue*/
-	if ranUe != nil && ranUe.AmfUe != nil {
-		ranUe.AmfUe.SetEventChannel(ctx, NgapMsgHandler)
-		ranUe.AmfUe.TxLog.Infoln("Uecontext found. queuing ngap message to uechannel")
-		ranUe.AmfUe.EventChannel.UpdateNgapHandler(NgapMsgHandler)
+	// One read of the association, used throughout. This runs on the connection's only
+	// reader goroutine, which has no recover(), so a re-read that lands after a release
+	// clears the pointer ends the process for every UE on every gNB, not just this one.
+	if amfUe := ranUe.GetAmfUe(); amfUe != nil {
+		amfUe.SetEventChannel(ctx, NgapMsgHandler)
+		amfUe.TxLog.Infoln("Uecontext found. queuing ngap message to uechannel")
+		amfUe.EventChannel.UpdateNgapHandler(NgapMsgHandler)
 		ngapMsg := context.NgapMsg{
 			Ran:       ran,
 			NgapMsg:   pdu,
 			SctplbMsg: nil,
 		}
 		if ranUe.Ran.GnbId == ran.GnbId {
-			ranUe.AmfUe.TxLog.Infoln("gnbid match")
+			amfUe.TxLog.Infoln("gnbid match")
 			ranUe.Ran.Conn = conn
 		} else {
-			ranUe.AmfUe.TxLog.Infoln("gnbid differ")
-			ranUe.AmfUe.TxLog.Infof("In case of Xn handover source RAN gNB id:%s, target RAN gNB id:%s", ranUe.Ran.GnbId, ran.GnbId)
+			amfUe.TxLog.Infoln("gnbid differ")
+			amfUe.TxLog.Infof("In case of Xn handover source RAN gNB id:%s, target RAN gNB id:%s", ranUe.Ran.GnbId, ran.GnbId)
 		}
-		ranUe.AmfUe.EventChannel.SubmitMessage(ngapMsg)
+		amfUe.EventChannel.SubmitMessage(ngapMsg)
 	} else {
 		go DispatchNgapMsg(ctx, ran, pdu, nil)
 	}

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -1188,7 +1188,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 	}
 
 	// Remove UE N2 Connection
-	amfUe.ReleaseCause[ran.AnType] = nil
+	amfUe.SetReleaseCause(ran.AnType, nil)
 	switch ranUe.ReleaseAction {
 	case context.UeContextN2NormalRelease:
 		ran.Log.Infof("Release UE[%s] Context : N2 Connection Release", amfUe.GetSupi())

--- a/ngap/message/send.go
+++ b/ngap/message/send.go
@@ -201,9 +201,9 @@ func SendUEContextReleaseCommand(ue *context.RanUe, action context.RelAction, ca
 	}
 	ue.ReleaseAction = action
 	if ue.AmfUe != nil && ue.Ran != nil {
-		ue.AmfUe.ReleaseCause[ue.Ran.AnType] = &context.CauseAll{
+		ue.AmfUe.SetReleaseCause(ue.Ran.AnType, &context.CauseAll{
 			NgapCause: models.NewNgApCause(int32(causePresent), int32(cause)),
-		}
+		})
 	}
 	SendToRanUe(ue, pkt)
 }

--- a/ngap/message/send.go
+++ b/ngap/message/send.go
@@ -200,8 +200,11 @@ func SendUEContextReleaseCommand(ue *context.RanUe, action context.RelAction, ca
 		return
 	}
 	ue.ReleaseAction = action
-	if ue.AmfUe != nil && ue.Ran != nil {
-		ue.AmfUe.SetReleaseCause(ue.Ran.AnType, &context.CauseAll{
+	// One read: checking ue.AmfUe and then calling through it are two separate reads of
+	// a field another goroutine clears, so the call can land on the nil the check just
+	// ruled out.
+	if amfUe := ue.GetAmfUe(); amfUe != nil && ue.Ran != nil {
+		amfUe.SetReleaseCause(ue.Ran.AnType, &context.CauseAll{
 			NgapCause: models.NewNgApCause(int32(causePresent), int32(cause)),
 		})
 	}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -408,7 +408,7 @@ func N1MessageNotifyProcedure(n1MessageNotify models.N1MessageNotifyRequest) *mo
 
 		if registrationCtxtContainer.AllowedNssai != nil {
 			allowedNssai := registrationCtxtContainer.AllowedNssai
-			amfUe.AllowedNssai[allowedNssai.AccessType] = allowedNssai.AllowedSnssaiList
+			amfUe.SetAllowedNssai(allowedNssai.AccessType, allowedNssai.AllowedSnssaiList)
 		}
 
 		if len(registrationCtxtContainer.ConfiguredNssai) > 0 {

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -87,8 +87,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		ueEventSubscription.AnyUe = true
 		amfSelf.UePool.Range(func(key, value interface{}) bool {
 			ue := value.(*context.AmfUe)
-			subscription := ueEventSubscription
-			ue.SetEventSubscription(newSubscriptionID, &subscription)
+			ueSubscription := ueEventSubscription
+			ue.SetEventSubscription(newSubscriptionID, &ueSubscription)
 			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			return true
 		})
@@ -98,8 +98,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		amfSelf.UePool.Range(func(key, value interface{}) bool {
 			ue := value.(*context.AmfUe)
 			if ue.GroupID == subscription.GetGroupId() {
-				subscription := ueEventSubscription
-				ue.SetEventSubscription(newSubscriptionID, &subscription)
+				ueSubscription := ueEventSubscription
+				ue.SetEventSubscription(newSubscriptionID, &ueSubscription)
 				contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			}
 			return true
@@ -109,8 +109,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 			problemDetails := utils.ProblemDetailsWithCause("UE not served by AMF", http.StatusForbidden, "UE is not served by this AMF", utils.CauseUeNotServedByAmf)
 			return nil, problemDetails
 		} else {
-			subscription := ueEventSubscription
-			ue.SetEventSubscription(newSubscriptionID, &subscription)
+			ueSubscription := ueEventSubscription
+			ue.SetEventSubscription(newSubscriptionID, &ueSubscription)
 			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 		}
 	}

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -87,8 +87,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		ueEventSubscription.AnyUe = true
 		amfSelf.UePool.Range(func(key, value interface{}) bool {
 			ue := value.(*context.AmfUe)
-			ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
-			*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
+			subscription := ueEventSubscription
+			ue.SetEventSubscription(newSubscriptionID, &subscription)
 			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			return true
 		})
@@ -98,8 +98,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		amfSelf.UePool.Range(func(key, value interface{}) bool {
 			ue := value.(*context.AmfUe)
 			if ue.GroupID == subscription.GetGroupId() {
-				ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
-				*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
+				subscription := ueEventSubscription
+				ue.SetEventSubscription(newSubscriptionID, &subscription)
 				contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 			}
 			return true
@@ -109,8 +109,8 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 			problemDetails := utils.ProblemDetailsWithCause("UE not served by AMF", http.StatusForbidden, "UE is not served by this AMF", utils.CauseUeNotServedByAmf)
 			return nil, problemDetails
 		} else {
-			ue.EventSubscriptionsInfo[newSubscriptionID] = new(context.AmfUeEventSubscription)
-			*ue.EventSubscriptionsInfo[newSubscriptionID] = ueEventSubscription
+			subscription := ueEventSubscription
+			ue.SetEventSubscription(newSubscriptionID, &subscription)
 			contextEventSubscription.UeSupiList = append(contextEventSubscription.UeSupiList, ue.GetSupi())
 		}
 	}
@@ -141,7 +141,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 			}
 			// delete subscription
 			if reportlistLen := len(reportlist); reportlistLen > 0 && (!reportlist[reportlistLen-1].State.Active) {
-				delete(ue.EventSubscriptionsInfo, newSubscriptionID)
+				ue.DeleteEventSubscription(newSubscriptionID)
 			}
 			return true
 		})
@@ -162,7 +162,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 				}
 				// delete subscription
 				if reportlistLen := len(reportlist); reportlistLen > 0 && (!reportlist[reportlistLen-1].State.Active) {
-					delete(ue.EventSubscriptionsInfo, newSubscriptionID)
+					ue.DeleteEventSubscription(newSubscriptionID)
 				}
 			}
 			return true
@@ -182,7 +182,7 @@ func CreateAMFEventSubscriptionProcedure(createEventSubscription models.AmfCreat
 		}
 		// delete subscription
 		if reportlistLen := len(reportlist); reportlistLen > 0 && (!reportlist[reportlistLen-1].State.Active) {
-			delete(ue.EventSubscriptionsInfo, newSubscriptionID)
+			ue.DeleteEventSubscription(newSubscriptionID)
 		}
 	}
 	if len(reportlist) > 0 {
@@ -220,7 +220,7 @@ func DeleteAMFEventSubscriptionProcedure(subscriptionID string) *models.ProblemD
 
 	for _, supi := range subscription.UeSupiList {
 		if ue, ok := amfSelf.AmfUeFindBySupi(supi); ok {
-			delete(ue.EventSubscriptionsInfo, subscriptionID)
+			ue.DeleteEventSubscription(subscriptionID)
 		}
 	}
 	amfSelf.DeleteEventSubscription(subscriptionID)


### PR DESCRIPTION
## What

Five faults in the AMF's UE-context handling, each of which ends the **whole process**
rather than the one procedure that hit it. At scale they are not rare: they aborted
10 000-session runs repeatedly, most recently twice inside five minutes in a single run.

They share a shape — state reachable from more than one goroutine, touched as if it were
reachable from one.

## The defects

**1. The `RanUe` → `AmfUe` association is read repeatedly and can be cleared between reads.**

`ngap.Dispatch`, `DispatchLb` and `nas.HandleNAS` each check `ranUe.AmfUe != nil` and then
dereference `ranUe.AmfUe` several more times. `Remove` and `DetachAmfUe` clear that field
from other goroutines, so a later read in the same function can return the nil the check
ruled out. `ngap.Dispatch` runs on the connection's only reader goroutine, which has no
`recover()`, so this is a SIGSEGV that takes down every UE on every gNB.

Fixed by guarding the field with a mutex and reading it **once** per function through
`GetAmfUe()`, then working from that pointer.

**2. Persisting a UE context iterates six maps that other goroutines write.**

`MarshalJSON` serialises `RanUe`, `OnGoing`, `RegistrationArea`, `AllowedNssai`,
`ReleaseCause` and `EventSubscriptionsInfo`. Writers run concurrently, so this is
`fatal error: concurrent map iteration and map write` — unrecoverable by construction.
`MarshalJSON` now takes `ue.Mutex`.

**3. A nil slice-selection response is ranged over.**

`GetNSSAIExecute` returns `(nil, resp, nil)` when the body is empty — a nil body is not an
error to the generated client — and `for _, s := range nssai.DefaultSingleNssais` then
dereferences it.

Worth noting for reviewers: guarding only the range is **not** sufficient, and we shipped
that first and it moved the crash rather than fixing it. With `nssai` nil-checked, the same
response falls into the `else if httpResp != nil` branch and evaluates
`localErr.Error()` on a nil error, one line further down. All four outcomes have to be told
apart, which is what this does.

**4. Every writer of those six maps took no lock, while the reader did.**

Fixing (2) alone leaves the race intact from the other side. Each map now has a guarded
mutator and the call sites route through it.

`AttachRanUe` also *dropped* the lock specifically to swap `ue.NASLog`/`GmmLog`/`TxLog`,
while methods holding that same lock log through them; the swap now happens under it.

**5. The AMF persists its own global singleton inside every UE context.**

`AmfUe.init()` sets `ue.ServingAMF = AMF_Self()`, and the field was declared
`json:"servingAMF,omitempty"` — so it was written to the database and read back.

Two consequences, both confirmed against a running deployment:

- Every UE document embedded a copy of the singleton's exported state — measured at
  **3 009 of a document's 6 574 bytes**.
- Restoring a UE decoded **straight back into the live singleton**. `AMFContext`
  serialises two real Go maps, `NfService` (the AMF's own service registry, used for NRF
  registration) and `LadnPool`. A single restore silently overwrites the running AMF's
  service registry with a snapshot from whenever that UE was stored; two concurrent
  restores are `fatal error: concurrent map writes`. Restores run on the NGAP reader
  goroutines, so several land together under load.

`json:"-"` fixes it. Both decode paths call `init()` first and every consumer —
`NrfUri`, `LadnPool`, `SupportDnnLists`, `NfId` — wants the running AMF rather than a
snapshot, so nothing needs it from the document. Documents written earlier keep the field
(the write path is a `$set` upsert) and the decoder now ignores it, so no migration.

## Evidence at scale

These were found by running 12 500 registrations across five gNBs at ~6.25/s. Before the
fixes, runs aborted part-way with the signatures above — the last such run took two aborts
five minutes apart and never recovered, because the RAN simulator does not re-establish
its SCTP association. After them, the same workload completes with **zero AMF aborts** and
10 833 UEs registered with PDU sessions, against a previous best of 9 720.

(The same test also measures user-plane throughput. That number was gated by an unrelated
UPF table-sizing problem and is not evidence for this change.)

## Verification

`go build`, `go vet` and `gofmt` clean; `go test -race ./...` green; `golangci-lint`
v2.11.3 — the version pinned in `.github/workflows/main.yml` — reports `0 issues` with
`golangci-lint fmt --diff ./...` producing no output. Run on linux/amd64 in CI's own
images.

New tests, each mutation-verified — the fix reverted makes the test fail, and with the
expected message:

- `TestStoringAContextWhileEveryMapIsWritten` drives every guarded mutator — eleven
  writers, plus a length accessor — against a goroutine marshalling the same UE, 2000
  rounds each. Removing the lock from one writer → 2 races and FAIL; from `MarshalJSON`
  → 103 races and FAIL.
- `TestAStoredContextDoesNotCarryTheAmf`, `TestRestoringAnOldDocumentLeavesTheRunningAmfAlone`
  and `TestConcurrentRestoresDoNotShareAMap`. The second is the interesting one: with the
  field restored it fails reporting the running AMF's name replaced by the stored
  snapshot's, which demonstrates the silent corruption rather than just the crash.

## Scope — what this does NOT do

**Readers of those six maps are still unguarded.** 66 direct accesses remain outside the
helpers (`RanUe` 42, `AllowedNssai` 13, `RegistrationArea` 8, `EventSubscriptionsInfo` 2,
`ReleaseCause` 1). An unguarded read racing a guarded write is still
`concurrent map read and map write`, and still fatal. What this closes is
marshal-versus-writer, which is the crash actually observed.

A follow-up will convert them. It is deliberately separate: two of those maps hold slices,
so a read accessor that returns the slice does not fix anything — the caller then ranges
over the backing array while `append` may write into it in place. Those accessors have to
copy, which is a different kind of change and wants its own review.

`RanUe.AmfUe` likewise stays exported; ~280 direct reads of it remain, on paths that
survive the nil either because they run on the UE's own goroutine or because
`SendToRan`'s `recover()` catches them. Unexporting it is a much larger diff.
