### PR TITLE
Pin that an SMF refusal with no reject is not relayed as an empty container

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -50,6 +50,9 @@ const (
 var (
 	sendDLNASTransport                    = gmm_message.SendDLNASTransport
 	sendReleaseSmContextRequest           = consumer.SendReleaseSmContextRequest
+	selectSmf                             = consumer.SelectSmf
+	sendCreateSmContextRequest            = consumer.SendCreateSmContextRequest
+	sendUpdateSmContextRequest            = consumer.SendUpdateSmContextRequest
 	getSubscribedNssaiForRegistration     = getSubscribedNssai
 	communicateWithUDMForRegistration     = communicateWithUDM
 	handleRequestedNssaiForRegistration   = handleRequestedNssai
@@ -227,7 +230,7 @@ func transport5GSMMessage(
 		}
 		dnn := pickDNN(ulNasTransport, ue, snssai)
 
-		newSmCtx, cause, err := consumer.SelectSmf(ctx, ue, anType, pduID, snssai, dnn)
+		newSmCtx, cause, err := selectSmf(ctx, ue, anType, pduID, snssai, dnn)
 		if err != nil {
 			ue.GmmLog.Errorf("select SMF failed: %+v", err)
 			m := new(nas.Message)
@@ -259,7 +262,7 @@ func transport5GSMMessage(
 			return nil
 		}
 
-		_, smCtxRef, errResp, prob, err := consumer.SendCreateSmContextRequest(ctx, ue, newSmCtx, nil, smMsg)
+		_, smCtxRef, errResp, prob, err := sendCreateSmContextRequest(ctx, ue, newSmCtx, nil, smMsg)
 		if err != nil {
 			ue.GmmLog.Errorf("createSmContextRequest Error: %+v", err)
 			return nil
@@ -501,7 +504,7 @@ func forward5GSMMessageToSMF(
 		smContextUpdateData.SetAnType(accessType)
 	}
 
-	response, errResponse, problemDetail, err := consumer.SendUpdateSmContextRequest(ctx, smContext,
+	response, errResponse, problemDetail, err := sendUpdateSmContextRequest(ctx, smContext,
 		smContextUpdateData, smMessage, nil)
 
 	if err != nil {

--- a/gmm/rejection_relay_test.go
+++ b/gmm/rejection_relay_test.go
@@ -65,7 +65,11 @@ func relayTestUe() *context.AmfUe {
 }
 
 // n1TempFile writes payload to a temp file shaped like the one openapi.Decode creates for a
-// multipart binary part. ReadAndCleanupBinaryTempFile removes it, so no cleanup is registered.
+// multipart binary part.
+//
+// The code under test removes the file when it reads it, but that cannot be relied on here: these
+// are built when the case table is built, so running one case with -run leaves the others' files
+// unread, and a case that fails before the read leaves its own. Removing again is harmless.
 func n1TempFile(t *testing.T, payload []byte) *os.File {
 	t.Helper()
 
@@ -73,6 +77,8 @@ func n1TempFile(t *testing.T, payload []byte) *os.File {
 	if err != nil {
 		t.Fatalf("creating the temp file: %v", err)
 	}
+	name := f.Name()
+	t.Cleanup(func() { _ = os.Remove(name) })
 	if _, err = f.Write(payload); err != nil {
 		t.Fatalf("writing the temp file: %v", err)
 	}
@@ -212,11 +218,16 @@ func establishmentRequestUL(pduSessionID uint8) *nasMessage.ULNASTransport {
 	requestType.SetRequestTypeValue(nasMessage.ULNASTransportRequestTypeInitialRequest)
 	ul.RequestType = requestType
 	payloadContainer := nasType.PayloadContainer{}
+	// SetLen allocates the buffer SetPayloadContainerContents copies into; without it the
+	// container arrives empty. No case asserts on the contents, since the create call is stubbed,
+	// but this is the payload the function forwards and it is worth being a real one.
 	payloadContainer.SetLen(4)
 	payloadContainer.SetPayloadContainerContents([]byte{0x2e, 0x01, 0x01, 0xc1})
 	ul.PayloadContainer = payloadContainer
+	// Only the presence of the DNN matters: it makes pickDNN return before it reads
+	// ue.ServingAMF, which is nil here, and the value goes to selectSmf, which the test stubs.
+	// SetDNN allocates the buffer and sets the length itself, unlike SetPayloadContainerContents.
 	dnn := nasType.NewDNN(nasMessage.ULNASTransportDNNType)
-	dnn.SetLen(9)
 	dnn.SetDNN([]byte("internet"))
 	ul.DNN = dnn
 

--- a/gmm/rejection_relay_test.go
+++ b/gmm/rejection_relay_test.go
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package gmm
+
+import (
+	ctxt "context"
+	"os"
+	"testing"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/factory"
+	"github.com/omec-project/nas/v2/nasMessage"
+	"github.com/omec-project/nas/v2/nasType"
+	"github.com/omec-project/openapi/v2"
+	"github.com/omec-project/openapi/v2/models"
+	"go.uber.org/zap"
+)
+
+// The SMF can refuse a PDU session without attaching a NAS reject: TS 29.502 allows the error
+// response to carry jsonData alone. Relaying that as a DL NAS transport would put an empty payload
+// container in front of the UE, which is not a message it can act on - so both rejection paths
+// check the payload before sending, and this file pins that they do.
+//
+// Reachability is what made these unpinned: the guards sit past a call into the consumer package,
+// which is why the pre-existing table test skips its SMF cases. They are reached here by stubbing
+// the consumer calls through the package vars gmm already uses for exactly this
+// (sendReleaseSmContextRequest and friends), so no SMF or NGAP harness is involved.
+
+// disableKafkaForRelayTest keeps PublishUeCtxtInfo out of the way: both relay paths call it, and it
+// dereferences factory.AmfConfig.Configuration.KafkaInfo.EnableKafka, which is nil in a unit test.
+// Mirrors the helper of the same shape in the ngap package's tests.
+func disableKafkaForRelayTest(t *testing.T) {
+	t.Helper()
+
+	originalConfig := factory.AmfConfig.Configuration
+	if originalConfig == nil {
+		factory.AmfConfig.Configuration = &factory.Configuration{}
+	}
+	originalEnableKafka := factory.AmfConfig.Configuration.KafkaInfo.EnableKafka
+	disabled := false
+	factory.AmfConfig.Configuration.KafkaInfo.EnableKafka = &disabled
+	t.Cleanup(func() {
+		if originalConfig == nil {
+			factory.AmfConfig.Configuration = nil
+
+			return
+		}
+		factory.AmfConfig.Configuration = originalConfig
+		factory.AmfConfig.Configuration.KafkaInfo.EnableKafka = originalEnableKafka
+	})
+}
+
+// relayTestUe is the minimum a UE needs to reach either guard: a logger, and a RanUe for the
+// access type, since the relay hands ue.GetRanUe(anType) to sendDLNASTransport.
+func relayTestUe() *context.AmfUe {
+	ue := &context.AmfUe{
+		GmmLog:       zap.NewNop().Sugar(),
+		RanUe:        make(map[models.AccessType]*context.RanUe),
+		AllowedNssai: map[models.AccessType][]models.AllowedSnssai{},
+	}
+	ue.RanUe[models.ACCESSTYPE__3_GPP_ACCESS] = &context.RanUe{AmfUe: ue}
+
+	return ue
+}
+
+// n1TempFile writes payload to a temp file shaped like the one openapi.Decode creates for a
+// multipart binary part. ReadAndCleanupBinaryTempFile removes it, so no cleanup is registered.
+func n1TempFile(t *testing.T, payload []byte) *os.File {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "n1smmessage")
+	if err != nil {
+		t.Fatalf("creating the temp file: %v", err)
+	}
+	if _, err = f.Write(payload); err != nil {
+		t.Fatalf("writing the temp file: %v", err)
+	}
+
+	return f
+}
+
+// captureDLNASTransport replaces sendDLNASTransport for the duration of the test and returns the
+// payloads it was called with.
+func captureDLNASTransport(t *testing.T) *[][]byte {
+	t.Helper()
+
+	original := sendDLNASTransport
+	sent := &[][]byte{}
+	sendDLNASTransport = func(_ *context.RanUe, _ models.AccessType, _ uint8, nasPdu []byte,
+		_ int32, _ uint8, _ *uint8, _ uint8,
+	) {
+		*sent = append(*sent, nasPdu)
+	}
+	t.Cleanup(func() { sendDLNASTransport = original })
+
+	return sent
+}
+
+func updateRejection(n1 *os.File) *models.UpdateSmContext400Response {
+	errResponse := models.NewUpdateSmContext400Response()
+	errResponse.SetJsonData(models.SmContextUpdateError{
+		Error: models.ExtProblemDetails{
+			Status: openapi.PtrInt32(403),
+			Cause:  openapi.PtrString("N1_SM_ERROR"),
+		},
+	})
+	if n1 != nil {
+		errResponse.SetBinaryDataN1SmMessage(n1)
+	}
+
+	return errResponse
+}
+
+// The modification path: forward5GSMMessageToSMF relays the reject the SMF returned, and sends
+// nothing when there is no reject to relay.
+func TestForwardRelaysOnlyARejectionThatCarriesAPayload(t *testing.T) {
+	reject := []byte{0x2e, 0x0a, 0xca, 0x20}
+
+	tests := []struct {
+		name     string
+		n1       *os.File
+		wantSent [][]byte
+	}{
+		{
+			name:     "a reject is relayed to the UE",
+			n1:       n1TempFile(t, reject),
+			wantSent: [][]byte{reject},
+		},
+		{
+			// TS 29.502 allows an error response carrying jsonData alone.
+			name:     "no N1 SM message: nothing is sent",
+			n1:       nil,
+			wantSent: nil,
+		},
+		{
+			// A part that decoded to zero bytes is the same thing by a different route.
+			name:     "an empty N1 SM message: nothing is sent",
+			n1:       n1TempFile(t, nil),
+			wantSent: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			disableKafkaForRelayTest(t)
+			sent := captureDLNASTransport(t)
+			originalUpdate := sendUpdateSmContextRequest
+			t.Cleanup(func() { sendUpdateSmContextRequest = originalUpdate })
+			sendUpdateSmContextRequest = func(_ ctxt.Context, _ *context.SmContext,
+				_ models.SmContextUpdateData, _ []byte, _ []byte,
+			) (*models.UpdateSmContext200Response, *models.UpdateSmContext400Response,
+				*models.ProblemDetails, error,
+			) {
+				return nil, updateRejection(tc.n1), nil, nil
+			}
+
+			ue := relayTestUe()
+			smContext := context.NewSmContext(10)
+
+			if err := forward5GSMMessageToSMF(ctxt.Background(), ue, models.ACCESSTYPE__3_GPP_ACCESS,
+				10, smContext, nil); err != nil {
+				t.Fatalf("forward5GSMMessageToSMF() = %v, want nil", err)
+			}
+
+			assertSent(t, *sent, tc.wantSent)
+		})
+	}
+}
+
+func assertSent(t *testing.T, got, want [][]byte) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		// The two directions are different defects, so they are reported as different things.
+		why := "a reject the SMF did attach must reach the UE"
+		if len(want) == 0 {
+			why = "an SMF refusal with no reject attached must not reach the UE as an empty payload container"
+		}
+		t.Fatalf("sendDLNASTransport called %d time(s), want %d: %s", len(got), len(want), why)
+	}
+	for i := range want {
+		if string(got[i]) != string(want[i]) {
+			t.Errorf("sendDLNASTransport payload %d = %#x, want %#x", i, got[i], want[i])
+		}
+	}
+}
+
+func createRejection(n1 *os.File) *models.PostSmContexts400Response {
+	errResponse := models.NewPostSmContexts400Response()
+	errResponse.SetJsonData(models.SmContextCreateError{
+		Error: models.ExtProblemDetails{
+			Status: openapi.PtrInt32(403),
+			Cause:  openapi.PtrString("N1_SM_ERROR"),
+		},
+	})
+	if n1 != nil {
+		errResponse.SetBinaryDataN1SmMessage(n1)
+	}
+
+	return errResponse
+}
+
+// establishmentRequestUL is an uplink NAS transport carrying a PDU session establishment request,
+// shaped so the create path is the one taken: an initial request type, a payload container to
+// forward, and a DNN, which keeps pickDNN off ue.ServingAMF.
+func establishmentRequestUL(pduSessionID uint8) *nasMessage.ULNASTransport {
+	ul := &nasMessage.ULNASTransport{}
+	ul.PduSessionID2Value = nasType.NewPduSessionID2Value(nasMessage.ULNASTransportPduSessionID2ValueType)
+	ul.SetPduSessionID2Value(pduSessionID)
+	requestType := nasType.NewRequestType(nasMessage.ULNASTransportRequestTypeType)
+	requestType.SetRequestTypeValue(nasMessage.ULNASTransportRequestTypeInitialRequest)
+	ul.RequestType = requestType
+	payloadContainer := nasType.PayloadContainer{}
+	payloadContainer.SetLen(4)
+	payloadContainer.SetPayloadContainerContents([]byte{0x2e, 0x01, 0x01, 0xc1})
+	ul.PayloadContainer = payloadContainer
+	dnn := nasType.NewDNN(nasMessage.ULNASTransportDNNType)
+	dnn.SetLen(9)
+	dnn.SetDNN([]byte("internet"))
+	ul.DNN = dnn
+
+	return ul
+}
+
+// The establishment path: transport5GSMMessage relays the reject the SMF returned, and sends
+// nothing when the refusal carries no reject.
+//
+// The guard sits past consumer.SelectSmf and the create request, which is why the pre-existing
+// table test skips its SMF cases. Both are stubbed through the package vars, so no SMF is needed.
+func TestTransportRelaysOnlyARejectionThatCarriesAPayload(t *testing.T) {
+	reject := []byte{0x2e, 0x0a, 0xc1, 0x46}
+
+	tests := []struct {
+		name     string
+		n1       *os.File
+		wantSent [][]byte
+	}{
+		{
+			name:     "a reject is relayed to the UE",
+			n1:       n1TempFile(t, reject),
+			wantSent: [][]byte{reject},
+		},
+		{
+			name:     "no N1 SM message: nothing is sent",
+			n1:       nil,
+			wantSent: nil,
+		},
+		{
+			name:     "an empty N1 SM message: nothing is sent",
+			n1:       n1TempFile(t, nil),
+			wantSent: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			disableKafkaForRelayTest(t)
+			sent := captureDLNASTransport(t)
+
+			originalSelect, originalCreate := selectSmf, sendCreateSmContextRequest
+			t.Cleanup(func() { selectSmf, sendCreateSmContextRequest = originalSelect, originalCreate })
+			selectSmf = func(_ ctxt.Context, _ *context.AmfUe, _ models.AccessType, pduSessionID int32,
+				_ models.Snssai, _ string,
+			) (*context.SmContext, uint8, error) {
+				return context.NewSmContext(pduSessionID), 0, nil
+			}
+			sendCreateSmContextRequest = func(_ ctxt.Context, _ *context.AmfUe, _ *context.SmContext,
+				_ *models.RequestType, _ []byte,
+			) (*models.PostSmContexts201Response, string, *models.PostSmContexts400Response,
+				*models.ProblemDetails, error,
+			) {
+				return nil, "", createRejection(tc.n1), nil, nil
+			}
+
+			ue := relayTestUe()
+			ue.AllowedNssai[models.ACCESSTYPE__3_GPP_ACCESS] = []models.AllowedSnssai{
+				{AllowedSnssai: models.Snssai{Sst: 1}},
+			}
+
+			if err := transport5GSMMessage(ctxt.Background(), ue, models.ACCESSTYPE__3_GPP_ACCESS,
+				establishmentRequestUL(10)); err != nil {
+				t.Fatalf("transport5GSMMessage() = %v, want nil", err)
+			}
+
+			assertSent(t, *sent, tc.wantSent)
+		})
+	}
+}

--- a/gmm/rejection_relay_test.go
+++ b/gmm/rejection_relay_test.go
@@ -67,9 +67,11 @@ func relayTestUe() *context.AmfUe {
 // n1TempFile writes payload to a temp file shaped like the one openapi.Decode creates for a
 // multipart binary part.
 //
-// The code under test removes the file when it reads it, but that cannot be relied on here: these
-// are built when the case table is built, so running one case with -run leaves the others' files
-// unread, and a case that fails before the read leaves its own. Removing again is harmless.
+// The code under test closes and removes the file when it reads it, but that cannot be relied on
+// here: these are built when the case table is built, so running one case with -run leaves the
+// others' files unread, and a case that fails before the read leaves its own. Closing and removing
+// again is harmless - a second Close reports the file as already closed without touching a
+// descriptor that by then may belong to another file.
 func n1TempFile(t *testing.T, payload []byte) *os.File {
 	t.Helper()
 
@@ -78,7 +80,10 @@ func n1TempFile(t *testing.T, payload []byte) *os.File {
 		t.Fatalf("creating the temp file: %v", err)
 	}
 	name := f.Name()
-	t.Cleanup(func() { _ = os.Remove(name) })
+	t.Cleanup(func() {
+		_ = f.Close()
+		_ = os.Remove(name)
+	})
 	if _, err = f.Write(payload); err != nil {
 		t.Fatalf("writing the temp file: %v", err)
 	}


### PR DESCRIPTION
## Why

The SMF can refuse a PDU session without attaching a NAS reject — TS 29.502 allows the error
response to carry `jsonData` alone. Relaying that would put an **empty payload container** in front
of the UE, which is not a message it can act on, so both rejection paths check the payload before
sending. Neither check was tested.

Reachability is why they were not. Both sit past a call into the `consumer` package, which is what
the existing table test means by:

```go
t.Skip("skipping test that requires SMF mocking")
```

So a later refactor could undo either guard silently.

## How they are reached without an SMF

By stubbing the consumer calls through package vars — the mechanism this file already uses for
`sendDLNASTransport` and `sendReleaseSmContextRequest`. No HTTP server, no NGAP, nothing
long-running.

The production change is three vars and three call-site swaps, with no behaviour change:

```go
selectSmf                  = consumer.SelectSmf
sendCreateSmContextRequest = consumer.SendCreateSmContextRequest
sendUpdateSmContextRequest = consumer.SendUpdateSmContextRequest
```

Only the call sites the tests drive are swapped, following how `sendReleaseSmContextRequest` is used
at two of its five sites rather than all of them.

## What is asserted

Each path — `transport5GSMMessage` (establishment) and `forward5GSMMessageToSMF` (modification) —
gets three cases:

| case | expected |
|---|---|
| the rejection carries a reject | relayed to the UE, with those exact bytes |
| no `binaryDataN1SmMessage` at all | nothing sent |
| a part that decoded to zero bytes | nothing sent |

The last two are separate deliberately: `ReadAndCleanupBinaryTempFile(nil)` already returns no
bytes, so **only the zero-byte case distinguishes the `len(...) == 0` guard from the `!= nil` test
it replaced.**

## Mutation-verified

| mutation | result |
|---|---|
| remove the establishment guard | both empty cases relay an empty container; test fails naming it |
| restore the modification path's `n1Msg != nil` | the zero-byte case relays; test fails |
| delete the relay call itself | the case expecting a relay fails |

The third one matters: it is what shows the tests reach the branch rather than passing vacuously.

## Not covered

The third guard of this shape, in `producer.SmContextStatusNotifyProcedure`. It runs inside a
goroutine, calls `gmm_message.SendDLNASTransport` directly in a package with no stub-var pattern,
and needs an AMF context with a UE findable by GUTI plus a stored ULNASTransport — so pinning it
means introducing that pattern to `producer` and synchronising on the goroutine, with a log line as
the only observable. That belongs in its own change rather than bolted on here.

## Verification

`golangci-lint` v2.13.2 in Docker with the repo config: **0 issues**. `staticcheck` v0.8.1, `gofmt`,
`gofumpt` and `gci` v0.14.0 clean. `go test -race` green across `gmm`, `consumer` and `context`. A
full `go build ./...` and the `gmm` suite were run in a `golang:1.26` container, both exit 0, since
`ngap/service` does not build on darwin. The commit was extracted with `git archive` into a clean
tree and re-tested there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyNr6vp6JaxxzPyVcuHXTf
