### PR TITLE
fix(metrics): stop reporting a departed gNB as still connected

### DIFF
--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -304,7 +304,8 @@ func (ran *AmfRan) SetRanStats(state string) {
 		// Writing both series means the state has to be one of the two the gauge
 		// describes. Treating anything else as disconnected would record a state nobody
 		// asked for, which is the same class of quiet wrongness as the stale series.
-		logger.ContextLog.Warnf("RAN state %q is not recorded on gnb_session_profile", state)
+		logger.ContextLog.Warnf("RAN %q state %q is not recorded on gnb_session_profile",
+			ran.RanID(), state)
 		return
 	}
 

--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -285,13 +285,22 @@ func (ran *AmfRan) RanID() string {
 	}
 }
 
+// SetRanStats records the RAN's connection state on the gnb_session_profile gauge.
+//
+// The state is a label, so writing only the series for the state being entered leaves the
+// series for the state being left at whatever it last held: a gNB that connected and then
+// disconnected went on reporting Connected=1 for the life of the process, and a dashboard
+// summing that series could not see the gNB go away. Both series are written on every
+// transition so that each one means what it says.
 func (ran *AmfRan) SetRanStats(state string) {
+	connected, disconnected := uint64(0), uint64(1)
+	if state == RanConnected {
+		connected, disconnected = 1, 0
+	}
+
 	snapshot := ran.statsSnapshot()
 	for _, tai := range snapshot.supportedTAList {
-		if state == RanConnected {
-			metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, state, tai.Tai.Tac, 1)
-		} else {
-			metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, state, tai.Tai.Tac, 0)
-		}
+		metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, RanConnected, tai.Tai.Tac, connected)
+		metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, RanDisconnected, tai.Tai.Tac, disconnected)
 	}
 }

--- a/context/amf_ran.go
+++ b/context/amf_ran.go
@@ -293,9 +293,19 @@ func (ran *AmfRan) RanID() string {
 // summing that series could not see the gNB go away. Both series are written on every
 // transition so that each one means what it says.
 func (ran *AmfRan) SetRanStats(state string) {
-	connected, disconnected := uint64(0), uint64(1)
-	if state == RanConnected {
+	var connected, disconnected uint64
+
+	switch state {
+	case RanConnected:
 		connected, disconnected = 1, 0
+	case RanDisconnected:
+		connected, disconnected = 0, 1
+	default:
+		// Writing both series means the state has to be one of the two the gauge
+		// describes. Treating anything else as disconnected would record a state nobody
+		// asked for, which is the same class of quiet wrongness as the stale series.
+		logger.ContextLog.Warnf("RAN state %q is not recorded on gnb_session_profile", state)
+		return
 	}
 
 	snapshot := ran.statsSnapshot()

--- a/context/amf_ran_stats_test.go
+++ b/context/amf_ran_stats_test.go
@@ -75,6 +75,24 @@ func TestSetRanStatsWritesBothStatesOnEveryTransition(t *testing.T) {
 	}
 }
 
+// A state the gauge does not describe is refused rather than recorded as its opposite,
+// which is what writing both series would otherwise turn an unknown value into.
+func TestSetRanStatsRefusesAnUnknownState(t *testing.T) {
+	ran := &AmfRan{
+		Name:            "gnb-unknown-state",
+		GnbIp:           "10.10.10.12",
+		SupportedTAList: []SupportedTAI{{Tai: models.Tai{Tac: "000009"}}},
+	}
+
+	ran.SetRanStats("Reconnecting")
+
+	for _, line := range strings.Split(gnbSessionProfileSeries(t), "\n") {
+		if strings.Contains(line, "gnb-unknown-state") {
+			t.Errorf("gnb_session_profile carries %q for a state the gauge does not describe", line)
+		}
+	}
+}
+
 // A RAN whose NGSetup carried no supported TA list has no series to write, and must not
 // panic on the way to finding that out.
 func TestSetRanStatsWithNoSupportedTAList(t *testing.T) {

--- a/context/amf_ran_stats_test.go
+++ b/context/amf_ran_stats_test.go
@@ -16,7 +16,10 @@ import (
 // gnbSessionProfileSeries returns the gnb_session_profile samples as "labels=value"
 // lines, sorted, so a test can state the whole family in one comparison. The gathered
 // types are used through their accessors only, so this needs no new module dependency.
-func gnbSessionProfileSeries(t *testing.T) string {
+// Scoped to the caller's own gNB id: asserting the whole family would couple this test
+// to every future test in the package that writes this metric, and break with a failure
+// naming the wrong culprit.
+func gnbSessionProfileSeries(t *testing.T, id string) string {
 	t.Helper()
 
 	families, err := prometheus.DefaultGatherer.Gather()
@@ -33,9 +36,19 @@ func gnbSessionProfileSeries(t *testing.T) string {
 
 		for _, metric := range family.GetMetric() {
 			labels := []string{}
+			mine := false
+
 			for _, label := range metric.GetLabel() {
 				labels = append(labels, label.GetName()+"="+label.GetValue())
+				if label.GetName() == "id" && label.GetValue() == id {
+					mine = true
+				}
 			}
+
+			if !mine {
+				continue
+			}
+
 			sort.Strings(labels)
 			lines = append(lines, fmt.Sprintf("{%s} %g", strings.Join(labels, ","), metric.GetGauge().GetValue()))
 		}
@@ -60,7 +73,7 @@ func TestSetRanStatsWritesBothStatesOnEveryTransition(t *testing.T) {
 
 	want := "{id=gnb-metric-test,ip=10.10.10.10,state=Connected,tac=000001} 1\n" +
 		"{id=gnb-metric-test,ip=10.10.10.10,state=Disconnected,tac=000001} 0"
-	if got := gnbSessionProfileSeries(t); got != want {
+	if got := gnbSessionProfileSeries(t, ran.Name); got != want {
 		t.Errorf("gnb_session_profile after connecting:\n%s\nwant:\n%s", got, want)
 	}
 
@@ -70,7 +83,7 @@ func TestSetRanStatsWritesBothStatesOnEveryTransition(t *testing.T) {
 	// dashboard summing that series could not see the gNB go away.
 	want = "{id=gnb-metric-test,ip=10.10.10.10,state=Connected,tac=000001} 0\n" +
 		"{id=gnb-metric-test,ip=10.10.10.10,state=Disconnected,tac=000001} 1"
-	if got := gnbSessionProfileSeries(t); got != want {
+	if got := gnbSessionProfileSeries(t, ran.Name); got != want {
 		t.Errorf("gnb_session_profile after disconnecting:\n%s\nwant:\n%s", got, want)
 	}
 }
@@ -86,10 +99,8 @@ func TestSetRanStatsRefusesAnUnknownState(t *testing.T) {
 
 	ran.SetRanStats("Reconnecting")
 
-	for _, line := range strings.Split(gnbSessionProfileSeries(t), "\n") {
-		if strings.Contains(line, "gnb-unknown-state") {
-			t.Errorf("gnb_session_profile carries %q for a state the gauge does not describe", line)
-		}
+	if got := gnbSessionProfileSeries(t, ran.Name); got != "" {
+		t.Errorf("gnb_session_profile carries %q for a state the gauge does not describe", got)
 	}
 }
 

--- a/context/amf_ran_stats_test.go
+++ b/context/amf_ran_stats_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/omec-project/openapi/v2/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// gnbSessionProfileSeries returns the gnb_session_profile samples as "labels=value"
+// lines, sorted, so a test can state the whole family in one comparison. The gathered
+// types are used through their accessors only, so this needs no new module dependency.
+func gnbSessionProfileSeries(t *testing.T) string {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather() = %v", err)
+	}
+
+	lines := []string{}
+
+	for _, family := range families {
+		if family.GetName() != "gnb_session_profile" {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			labels := []string{}
+			for _, label := range metric.GetLabel() {
+				labels = append(labels, label.GetName()+"="+label.GetValue())
+			}
+			sort.Strings(labels)
+			lines = append(lines, fmt.Sprintf("{%s} %g", strings.Join(labels, ","), metric.GetGauge().GetValue()))
+		}
+	}
+
+	sort.Strings(lines)
+
+	return strings.Join(lines, "\n")
+}
+
+// The gauge carries the RAN's state as a label, so a transition has to write both series
+// or the one being left keeps the value it had. This test owns the whole metric family in
+// this package: nothing else here writes it.
+func TestSetRanStatsWritesBothStatesOnEveryTransition(t *testing.T) {
+	ran := &AmfRan{
+		Name:            "gnb-metric-test",
+		GnbIp:           "10.10.10.10",
+		SupportedTAList: []SupportedTAI{{Tai: models.Tai{Tac: "000001"}}},
+	}
+
+	ran.SetRanStats(RanConnected)
+
+	want := "{id=gnb-metric-test,ip=10.10.10.10,state=Connected,tac=000001} 1\n" +
+		"{id=gnb-metric-test,ip=10.10.10.10,state=Disconnected,tac=000001} 0"
+	if got := gnbSessionProfileSeries(t); got != want {
+		t.Errorf("gnb_session_profile after connecting:\n%s\nwant:\n%s", got, want)
+	}
+
+	ran.SetRanStats(RanDisconnected)
+
+	// The half that was wrong: Connected stayed at 1 for the life of the process, so a
+	// dashboard summing that series could not see the gNB go away.
+	want = "{id=gnb-metric-test,ip=10.10.10.10,state=Connected,tac=000001} 0\n" +
+		"{id=gnb-metric-test,ip=10.10.10.10,state=Disconnected,tac=000001} 1"
+	if got := gnbSessionProfileSeries(t); got != want {
+		t.Errorf("gnb_session_profile after disconnecting:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A RAN whose NGSetup carried no supported TA list has no series to write, and must not
+// panic on the way to finding that out.
+func TestSetRanStatsWithNoSupportedTAList(t *testing.T) {
+	ran := &AmfRan{Name: "gnb-no-tai", GnbIp: "10.10.10.11"}
+
+	ran.SetRanStats(RanConnected)
+	ran.SetRanStats(RanDisconnected)
+}


### PR DESCRIPTION
## The defect

`gnb_session_profile` carries the RAN's connection state as a **label**, and `SetRanStats` writes
only the series for the state being entered:

```go
if state == RanConnected {
	metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, state, tai.Tai.Tac, 1)
} else {
	metrics.SetGnbSessProfileStats(snapshot.name, snapshot.gnbIP, state, tai.Tai.Tac, 0)
}
```

NG Setup (`ngap/message/send.go`) sets `{state="Connected"} = 1`. Removal
(`context/amf_ran.go`) sets `{state="Disconnected"} = 0` — a *different* series. Nothing writes
the `Connected` series again, and nothing deletes it: `DeleteLabelValues` appears nowhere in the
repository. So it stays at 1 for the life of the process.

Two consequences, both on the only metric the AMF publishes about its RANs:

- `sum(gnb_session_profile{state="Connected"})` counts every gNB that has **ever** connected, so a
  gNB going away is invisible.
- `{state="Disconnected"}` reads **0** for a gNB that is disconnected, which is the opposite of
  what it says.

We found this while working out why an AMF that had lost all four of its SCTP associations looked
healthy from the outside for thirty minutes. It was not the cause, but it is the reason no
dashboard could have shown the loss.

## The change

Write both series on every transition, so each one means what it says: connecting sets
`Connected=1` and `Disconnected=0`, removal sets `Connected=0` and `Disconnected=1`. The label set
is unchanged, so existing queries keep working — they stop being wrong.

`SetGnbSessProfileStats` has exactly one caller, so this is the whole of the metric's write path.

## One thing this rewrite got wrong on the first pass

Writing both series means the state has to be one of the two the gauge describes, and the first
version of this change simply treated "not Connected" as disconnected. That turned an unknown
state string from *its own series* into *silently recorded as the opposite* — the same class of
quiet wrongness the change exists to fix. It now refuses a state it does not recognise, with a
warning, and a test asserts that no series is written for one.

No caller passes anything else today (`ngap/message/send.go` passes `RanConnected`,
`context/amf_ran.go` passes `RanDisconnected`), so this is about the next caller rather than a
present bug.

## What a consumer will see change, beyond the fix

- **A gNB whose NG Setup was refused now populates `Disconnected=1`.** The TA list is stored on
  the RAN before the checks that can fail the setup, so a refused RAN reaches `Remove()` with TACs
  but was never `Connected=1`. Before, it emitted `Disconnected=0`; now it emits `Connected=0,
  Disconnected=1`. Truthful — that RAN is not connected — but it means
  `gnb_session_profile{state="Disconnected"} == 1` counts refused setups alongside departures.
- The series remain **per (gNB, TAC)** rather than per gNB, unchanged by this PR.

## The class this does not close

Both are pre-existing, neither is introduced here, and both are the same shape — a series written
once and never revisited — so it is worth saying plainly that the fix does not reach them:

- **`HandleRanConfigurationUpdate` never calls `SetRanStats`.** It appends the TACs it learns to
  `ran.SupportedTAList`, so a TAC added after NG Setup is not published as `Connected=1` while the
  gNB is up, and first appears at removal as `Connected=0, Disconnected=1`. A dashboard
  under-counts that TAC for the life of the association. (That path also appends without the reset
  `HandleNGSetupRequest` does, which is a separate defect I am not touching here.)
- **A second NG Setup with a different TA list orphans the TACs it drops.** The reset clears
  `SupportedTAList`, so the removed TACs never receive their `Connected=0` — the original defect,
  one level down. Closing it properly means deleting the RAN's series before rewriting them
  (`DeletePartialMatch` on the `id`/`ip` labels) or moving the state out of a label, which is the
  shape this PR already lists as out of scope.

## Deliberately not changed

The metric's shape. A single gauge whose *value* carries the state, with no `state` label, is the
more idiomatic modelling and would make this class of bug impossible — but it breaks every query
that selects on `state`, and that is a separate decision from fixing the lie.

## Verification

All on linux/amd64, in a container at CI's pinned versions:

- `go build ./...` and `go vet ./...` clean.
- `go test ./... -race -count=1` — ok.
- `golangci-lint run --config .golangci.yml ./...` at **v2.13.2**: 0 issues; `golangci-lint fmt
  --diff` empty.
- Three tests in `context/amf_ran_stats_test.go`: a connect-then-disconnect transition, asserting
  the **whole** `gnb_session_profile` family after each step, and a RAN whose NGSetup carried no
  supported TA list, which has no series to write and must not panic finding that out; and a state
  the gauge does not describe, which must leave the family untouched. The
  assertion gathers from the default registry through the gathered types' accessors, so it adds no
  module dependency (`prometheus/testutil` would have needed `go.mod` entries).
- **Mutation-verified, both ways.** Against the pre-change function both transition assertions
  fail, and the second failure prints the defect itself: `state=Connected 1` and
  `state=Disconnected 0` after the disconnect. And with the unknown-state arm reverted to
  "treat it as disconnected", the third test fails naming both series it would have written.
