### PR TITLE
feat(metrics): report the NGAP association count and last-message time

### DIFF
--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -14,7 +14,6 @@ package metrics
 import (
 	"encoding/hex"
 	"net/http"
-	"time"
 	"unicode/utf8"
 
 	"github.com/omec-project/amf/logger"
@@ -60,9 +59,10 @@ func initAmfStats() *AmfStats {
 
 		ngapLastMessage: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "amf_ngap_last_message_timestamp_seconds",
-			Help: "Unix time of the last NGAP message this AMF handled, or zero if it has " +
-				"handled none. Exposed as a timestamp rather than an age so that the staleness " +
-				"is computed at query time.",
+			Help: "Unix time of the last NGAP message this AMF received and decoded, or zero " +
+				"if it has received none. It advances at intake, before the message is " +
+				"handled, so a stalled handler behind a live intake still moves it. Exposed " +
+				"as a timestamp rather than an age so that staleness is computed at query time.",
 		}),
 	}
 }
@@ -143,11 +143,12 @@ func SetNgapAssociations(count int) {
 	amfStats.ngapAssociations.Set(float64(count))
 }
 
-// SetNgapLastMessage records that an NGAP message was handled at t. Paired with the
-// association count, a timestamp that stops advancing while the count is non-zero is a
-// different fault from the count going to zero, and the two are worth telling apart.
-func SetNgapLastMessage(t time.Time) {
-	amfStats.ngapLastMessage.Set(float64(t.Unix()))
+// SetNgapLastMessage records that an NGAP message has just been received and decoded.
+// Paired with the association count, a timestamp that stops advancing while the count is
+// non-zero is a different fault from the count going to zero, and the two are worth
+// telling apart.
+func SetNgapLastMessage() {
+	amfStats.ngapLastMessage.SetToCurrentTime()
 }
 
 // IncrementDbWriteDropped increments the counter of UE context writes dropped

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -14,6 +14,7 @@ package metrics
 import (
 	"encoding/hex"
 	"net/http"
+	"time"
 	"unicode/utf8"
 
 	"github.com/omec-project/amf/logger"
@@ -26,6 +27,8 @@ type AmfStats struct {
 	ngapMsg           *prometheus.CounterVec
 	gnbSessionProfile *prometheus.GaugeVec
 	dbWriteDropped    prometheus.Counter
+	ngapAssociations  prometheus.Gauge
+	ngapLastMessage   prometheus.Gauge
 }
 
 var amfStats *AmfStats
@@ -46,6 +49,21 @@ func initAmfStats() *AmfStats {
 			Name: "amf_db_write_dropped_total",
 			Help: "Total number of UE context DB writes dropped due to a full write queue.",
 		}),
+
+		ngapAssociations: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "amf_ngap_associations",
+			Help: "Number of SCTP associations this AMF terminates itself. The listener is " +
+				"started in either mode, so in a deployment whose gNBs connect to the SCTP " +
+				"load balancer this AMF accepts none and the value stays zero: it counts " +
+				"what this process terminates, not what it serves.",
+		}),
+
+		ngapLastMessage: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "amf_ngap_last_message_timestamp_seconds",
+			Help: "Unix time of the last NGAP message this AMF handled, or zero if it has " +
+				"handled none. Exposed as a timestamp rather than an age so that the staleness " +
+				"is computed at query time.",
+		}),
 	}
 }
 
@@ -60,6 +78,14 @@ func (ps *AmfStats) register() error {
 	}
 	prometheus.Unregister(ps.dbWriteDropped)
 	if err := prometheus.Register(ps.dbWriteDropped); err != nil {
+		return err
+	}
+	prometheus.Unregister(ps.ngapAssociations)
+	if err := prometheus.Register(ps.ngapAssociations); err != nil {
+		return err
+	}
+	prometheus.Unregister(ps.ngapLastMessage)
+	if err := prometheus.Register(ps.ngapLastMessage); err != nil {
 		return err
 	}
 	return nil
@@ -108,6 +134,20 @@ func SetGnbSessProfileStats(id, ip, state, tac string, count uint64) {
 	state = sanitizeLabelValue(state)
 	tac = sanitizeLabelValue(tac)
 	amfStats.gnbSessionProfile.WithLabelValues(id, ip, state, tac).Set(float64(count))
+}
+
+// SetNgapAssociations records how many SCTP associations the AMF currently terminates.
+// An AMF that has lost every association is indistinguishable from an idle one in its
+// logs, which is what this makes visible from outside the pod.
+func SetNgapAssociations(count int) {
+	amfStats.ngapAssociations.Set(float64(count))
+}
+
+// SetNgapLastMessage records that an NGAP message was handled at t. Paired with the
+// association count, a timestamp that stops advancing while the count is non-zero is a
+// different fault from the count going to zero, and the two are worth telling apart.
+func SetNgapLastMessage(t time.Time) {
+	amfStats.ngapLastMessage.Set(float64(t.Unix()))
 }
 
 // IncrementDbWriteDropped increments the counter of UE context writes dropped

--- a/ngap/dispatcher.go
+++ b/ngap/dispatcher.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"time"
 
 	"github.com/ishidawataru/sctp"
 	"github.com/omec-project/amf/context"
@@ -78,7 +77,7 @@ func DispatchLb(ctx ctxt.Context, sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2
 		return
 	}
 
-	metrics.SetNgapLastMessage(time.Now())
+	metrics.SetNgapLastMessage()
 
 	ranUe, ngapId := FetchRanUeContext(ran, pdu)
 	if ngapId != nil {
@@ -171,7 +170,7 @@ func Dispatch(conn net.Conn, msg []byte) {
 		return
 	}
 
-	metrics.SetNgapLastMessage(time.Now())
+	metrics.SetNgapLastMessage()
 
 	ranUe, _ := FetchRanUeContext(ran, pdu)
 

--- a/ngap/dispatcher.go
+++ b/ngap/dispatcher.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/ishidawataru/sctp"
 	"github.com/omec-project/amf/context"
@@ -76,6 +77,8 @@ func DispatchLb(ctx ctxt.Context, sctplbMsg *sdcoreAmfServer.SctplbMessage, Amf2
 		logger.NgapLog.Infoln("dispatchLb, decode Messgae error", sctplbMsg.GnbId)
 		return
 	}
+
+	metrics.SetNgapLastMessage(time.Now())
 
 	ranUe, ngapId := FetchRanUeContext(ran, pdu)
 	if ngapId != nil {
@@ -167,6 +170,8 @@ func Dispatch(conn net.Conn, msg []byte) {
 		ran.Log.Errorf("NGAP decode error: %+v", err)
 		return
 	}
+
+	metrics.SetNgapLastMessage(time.Now())
 
 	ranUe, _ := FetchRanUeContext(ran, pdu)
 

--- a/ngap/service/metrics_test.go
+++ b/ngap/service/metrics_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// gaugeValue reads a single unlabelled gauge back out of the default registry. The
+// gathered types are used through their accessors only, so this needs no new module
+// dependency.
+func gaugeValue(t *testing.T, name string) (float64, bool) {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather() = %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			return metric.GetGauge().GetValue(), true
+		}
+	}
+
+	return 0, false
+}
+
+func assertAssociations(t *testing.T, when string, want float64) {
+	t.Helper()
+
+	got, ok := gaugeValue(t, "amf_ngap_associations")
+	if !ok {
+		t.Fatal("amf_ngap_associations is not in the registry: a gauge that is not registered never reaches /metrics")
+	}
+
+	if got != want {
+		t.Errorf("amf_ngap_associations %s = %v, want %v", when, got, want)
+	}
+}
+
+// The gauge exists so that an AMF holding no association is visible from outside the pod,
+// where it otherwise looks exactly like an idle one. What it must track is the map the
+// listener keeps, through both transitions.
+func TestAssociationCountFollowsTheConnectionMap(t *testing.T) {
+	t.Cleanup(func() {
+		connections.Range(func(key, _ any) bool {
+			connections.Delete(key)
+			return true
+		})
+		reportAssociationCount()
+	})
+
+	reportAssociationCount()
+	assertAssociations(t, "with no associations", 0)
+
+	first, firstPeer := net.Pipe()
+	defer first.Close()
+	defer firstPeer.Close()
+
+	second, secondPeer := net.Pipe()
+	defer second.Close()
+	defer secondPeer.Close()
+
+	connections.Store(first, true)
+	reportAssociationCount()
+	assertAssociations(t, "with one association", 1)
+
+	connections.Store(second, true)
+	reportAssociationCount()
+	assertAssociations(t, "with two associations", 2)
+
+	// The direction that matters: an association going away has to move the gauge, which
+	// is the whole reason for reporting it from the map rather than from AmfRanPool.
+	connections.Delete(second)
+	reportAssociationCount()
+	assertAssociations(t, "after one association closed", 1)
+
+	connections.Delete(first)
+	reportAssociationCount()
+	assertAssociations(t, "after every association closed", 0)
+}
+
+// A gauge whose Set is wired but whose registration was forgotten reads as absent rather
+// than as wrong, which is the harder failure to notice.
+func TestNgapLastMessageGaugeIsRegistered(t *testing.T) {
+	if _, ok := gaugeValue(t, "amf_ngap_last_message_timestamp_seconds"); !ok {
+		t.Error("amf_ngap_last_message_timestamp_seconds is not in the registry")
+	}
+}

--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ishidawataru/sctp"
 	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/amf/metrics"
 	"github.com/omec-project/ngap/v2"
 )
 
@@ -31,6 +32,7 @@ var readTimeout syscall.Timeval = syscall.Timeval{Sec: 2, Usec: 0}
 var (
 	sctpListener *sctp.SCTPListener
 	connections  sync.Map
+	countMu      sync.Mutex
 )
 
 var handler NGAPHandler
@@ -167,9 +169,29 @@ func listenAndServe(addr *sctp.SCTPAddr, handler NGAPHandler) {
 
 		logger.NgapLog.Infof("[AMF] SCTP Accept from: %+v", newConn.RemoteAddr())
 		connections.Store(newConn, true)
+		reportAssociationCount()
 
 		go handleConnection(newConn, readBufSize, handler)
 	}
+}
+
+// reportAssociationCount publishes how many associations the listener holds. The map is
+// the authority for that number: AmfRanPool is keyed three ways — by connection, by remote
+// address and by GnbId — so its length counts keys rather than associations.
+//
+// The count and the publish are taken under one lock so that two associations changing at
+// once cannot leave the gauge holding the earlier of the two counts until the next event.
+func reportAssociationCount() {
+	countMu.Lock()
+	defer countMu.Unlock()
+
+	count := 0
+	connections.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+
+	metrics.SetNgapAssociations(count)
 }
 
 func Stop() {
@@ -195,6 +217,7 @@ func handleConnection(conn *sctp.SCTPConn, bufsize uint32, handler NGAPHandler) 
 
 	defer func() {
 		connections.Delete(conn)
+		reportAssociationCount()
 
 		// Notify the NGAP dispatcher that this RAN connection has closed so that
 		// its AmfRan entry is removed from AmfRanPool


### PR DESCRIPTION
## Why

An AMF that has lost every SCTP association keeps running, answers on its SBI, and logs nothing.
From outside the pod it is indistinguishable from an idle one. We spent thirty minutes of a
10 000-UE run in exactly that state — all four associations gone within 2 ms of each other with
`ETIMEDOUT`, `restartCount` still 0, the listener still bound on 38412, `/proc/net/sctp/assocs`
empty — and nothing the AMF publishes could have shown it. The run appeared to be progressing.

## What this adds

Two gauges, both on the existing `:9089` metrics endpoint:

- **`amf_ngap_associations`** — how many SCTP associations this AMF currently terminates, updated
  where the listener registers an accepted association and where the connection handler drops it.
- **`amf_ngap_last_message_timestamp_seconds`** — when an NGAP message was last **received and
  decoded**, stamped on both intake paths (`Dispatch` for direct SCTP and `DispatchLb` for the
  load-balanced one). The wording is deliberate: the stamp sits after the decode and before the
  message is queued, so a stalled *handler* behind a live intake still advances it, and a message
  that fails to decode does not. "Handled" would have overstated it in exactly the fault this is
  meant to expose.

They are useful together rather than separately: the count going to zero means no RAN, while the
timestamp standing still with a non-zero count means a RAN is attached and nothing is being
processed. Those are different faults with the same symptom, and today neither is visible.

## Two things worth stating about the count

- **It comes from the listener's own map, not from `AmfRanPool`.** That pool is a single
  `sync.Map` keyed three ways — by `net.Conn`, by remote address, and by GnbId string — so its
  length counts keys rather than associations, and it is not a count of anything in particular.
- **With the SCTP load balancer in use it stays 0, and the Help string says why.** The listener
  is started either way — `ngap_service.Run` is not conditional on the mode — so this is not a
  matter of the listener being absent: the gNBs connect to the load balancer, so this AMF accepts
  nothing. The gauge counts what this process terminates rather than what it serves, and a
  dashboard should not read it as "no RAN" in that deployment. The last-message timestamp stays
  meaningful there, since the load-balanced dispatcher stamps it too.

The count and its publish are taken under one lock, so two associations changing at once cannot
leave the gauge holding the earlier of the two counts until the next event moves it.

## Deliberately not here

The health signal these numbers exist to support. A liveness assertion — that an AMF which has
held an association and now holds none is unhealthy — needs a latch to distinguish "never served"
from "stopped serving", and that is a behaviour change rather than an observation. It follows in
its own pull request; this one only makes the state visible.

## Verification

All on linux/amd64, in a container at CI's pinned versions:

- `go build ./...`, `go vet ./...` clean; `go test ./... -race -count=1` ok.
- `golangci-lint run --config .golangci.yml ./...` at **v2.13.2**: 0 issues; `golangci-lint fmt
  --diff` empty.
- New tests in `ngap/service/metrics_test.go` drive the **reporting helper** through both
  directions — none, one, two, one, none — using `net.Pipe` associations so the test needs no
  socket, and assert that the timestamp gauge is *registered*, because a gauge that is set but
  never registered reads as absent rather than as wrong, which is the harder failure to notice.
  The assertions gather from the default registry through the gathered types' accessors, so they
  add no module dependency.

  **Being exact about what that does not cover:** the tests call the helper themselves, so
  removing either production call site — the accept path or the `handleConnection` defer — would
  leave them green. `handleConnection` takes a `*sctp.SCTPConn`, so the call sites cannot be
  driven from `net.Pipe`; exercising them needs a real listener and a kernel with SCTP, which is
  what the sibling shutdown change's test does. I considered a `var publish = reportAssociationCount`
  indirection to make the defer assertable and judged it more machinery than this change earns.

## Two properties of the count, for whoever builds on it

Neither is a defect here, and both matter to anything that reads this gauge as a health signal:

- **It tracks the handler goroutine's lifetime, not the kernel's view of the association.** The
  count drops when `SCTPRead` returns a terminal error. A graceful peer shutdown is immediate; a
  peer that goes silent without closing is noticed only when SCTP heartbeats give up, which is
  minutes at kernel defaults. Anything deriving an alarm from this inherits that latency.
- **A listener that never binds leaves the gauge at 0**, which is indistinguishable from "no RAN
  has connected yet". `listenAndServe` logs and returns if `Listen` fails, so an AMF that can
  never serve publishes the same value as one that is merely idle.
