### PR TITLE
feat(ngap): report an AMF that has stopped serving as unhealthy

### DIFF
--- a/metrics/health_test.go
+++ b/metrics/health_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHealthHandlerRefusesWhenTheCheckFails(t *testing.T) {
+	handler := HealthHandler(func() (bool, string) { return false, "every NGAP association has been lost" })
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil))
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+
+	// The reason travels in the body because a probe failure is otherwise a bare 503 in
+	// the kubelet's events, with nothing saying which condition fired.
+	if !strings.Contains(recorder.Body.String(), "every NGAP association has been lost") {
+		t.Errorf("body = %q, want it to carry the check's reason", recorder.Body.String())
+	}
+}
+
+func TestHealthHandlerAcceptsWhenTheCheckPasses(t *testing.T) {
+	handler := HealthHandler(func() (bool, string) { return true, "serving" })
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	if !strings.Contains(recorder.Body.String(), "serving") {
+		t.Errorf("body = %q, want it to carry the check's reason", recorder.Body.String())
+	}
+}

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -13,6 +13,7 @@ package metrics
 
 import (
 	"encoding/hex"
+	"io"
 	"net/http"
 	"unicode/utf8"
 
@@ -112,6 +113,32 @@ func init() {
 	if err := amfStats.register(); err != nil {
 		logger.AppLog.Errorln("AMF Stats register failed", err)
 	}
+}
+
+// HealthHandler answers a liveness probe from check, which reports whether the element
+// can serve and why not when it cannot. The check is passed in rather than read from here,
+// because the state it describes belongs to the NGAP layer and this package must stay
+// importable from it.
+func HealthHandler(check func() (bool, string)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		healthy, reason := check()
+
+		body := "ok: " + reason + "\n"
+		if !healthy {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			body = "unhealthy: " + reason + "\n"
+		}
+
+		if _, err := io.WriteString(w, body); err != nil {
+			logger.AppLog.Errorf("could not write health response: %v", err)
+		}
+	})
+}
+
+// RegisterHealth publishes the liveness endpoint on the same mux and port as /metrics, so
+// no new listener is involved.
+func RegisterHealth(check func() (bool, string)) {
+	http.Handle("/healthz", HealthHandler(check))
 }
 
 // InitMetrics initialises AMF stats

--- a/ngap/service/health_test.go
+++ b/ngap/service/health_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ishidawataru/sctp"
+	"github.com/omec-project/amf/context"
 )
 
 // withCleanState runs a case against a known listener state and puts back whatever the
@@ -91,6 +92,18 @@ func TestHealthyWhileShuttingDown(t *testing.T) {
 	}
 }
 
+// withSctpLb runs a case against a known deployment mode and puts back what the context held.
+func withSctpLb(t *testing.T, enabled bool) {
+	t.Helper()
+
+	self := context.AMF_Self()
+	was := self.EnableSctpLb
+
+	t.Cleanup(func() { self.EnableSctpLb = was })
+
+	self.EnableSctpLb = enabled
+}
+
 // The fault above reached from the other side: an AMF whose listener never bound has served
 // nobody and never can, and Run starts exactly one listenAndServe with nothing to retry it.
 // Until this it answered the liveness endpoint with "no NGAP association has been served
@@ -102,6 +115,7 @@ func TestHealthyWhileShuttingDown(t *testing.T) {
 // bindFailed itself cannot fail if the bind path never stores it.
 func TestUnhealthyWhenTheListenerNeverBound(t *testing.T) {
 	withCleanState(t)
+	withSctpLb(t, false)
 
 	// TEST-NET-1, which is not a local address, so the bind cannot succeed.
 	listenAndServe(&sctp.SCTPAddr{
@@ -120,5 +134,29 @@ func TestUnhealthyWhenTheListenerNeverBound(t *testing.T) {
 
 	if reason == "" {
 		t.Error("Healthy() gave no reason for being unhealthy, which is what a probe's logs need")
+	}
+}
+
+// Run is called whether or not the SCTP load balancer fronts this AMF, so an AMF that serves
+// gNB traffic over gRPC from sctplb still opens this listener and then never uses it. A failed
+// bind there says nothing about whether that AMF can serve, and restarting it for an unused
+// socket would be the false positive this signal exists to avoid. What such a deployment's
+// health does rest on - the gRPC listener - is not represented here at all, which is why this
+// only declines to claim a fault rather than claiming health on its behalf.
+func TestALoadBalancedAmfIsNotUnhealthyForAnUnusedListener(t *testing.T) {
+	withCleanState(t)
+	withSctpLb(t, true)
+
+	listenAndServe(&sctp.SCTPAddr{
+		IPAddrs: []net.IPAddr{{IP: net.ParseIP("192.0.2.1")}},
+		Port:    38412,
+	}, NGAPHandler{})
+
+	if !bindFailed.Load() {
+		t.Fatal("listenAndServe returned without recording the bind failure")
+	}
+
+	if healthy, reason := Healthy(); !healthy {
+		t.Errorf("Healthy() = false (%s) for an AMF whose gNBs arrive through sctplb, want true", reason)
 	}
 }

--- a/ngap/service/health_test.go
+++ b/ngap/service/health_test.go
@@ -6,18 +6,21 @@ package service
 import (
 	"net"
 	"testing"
+
+	"github.com/ishidawataru/sctp"
 )
 
 // withCleanState runs a case against a known listener state and puts back whatever the
-// package held, so the four cases below stay independent of their order.
+// package held, so the cases below stay independent of their order.
 func withCleanState(t *testing.T) {
 	t.Helper()
 
-	wasServed, wasShuttingDown := served.Load(), shuttingDown.Load()
+	wasServed, wasShuttingDown, wasBindFailed := served.Load(), shuttingDown.Load(), bindFailed.Load()
 
 	t.Cleanup(func() {
 		served.Store(wasServed)
 		shuttingDown.Store(wasShuttingDown)
+		bindFailed.Store(wasBindFailed)
 		connections.Range(func(key, _ any) bool {
 			connections.Delete(key)
 			return true
@@ -26,6 +29,7 @@ func withCleanState(t *testing.T) {
 
 	served.Store(false)
 	shuttingDown.Store(false)
+	bindFailed.Store(false)
 	connections.Range(func(key, _ any) bool {
 		connections.Delete(key)
 		return true
@@ -84,5 +88,37 @@ func TestHealthyWhileShuttingDown(t *testing.T) {
 
 	if healthy, reason := Healthy(); !healthy {
 		t.Errorf("Healthy() = false (%s) during shutdown, want true", reason)
+	}
+}
+
+// The fault above reached from the other side: an AMF whose listener never bound has served
+// nobody and never can, and Run starts exactly one listenAndServe with nothing to retry it.
+// Until this it answered the liveness endpoint with "no NGAP association has been served
+// yet" - the same answer a healthy AMF waiting for its first gNB gives - so from outside the
+// two were indistinguishable, and the element that could never serve was the one being left
+// alone.
+//
+// This drives listenAndServe rather than setting the flag, because a test that stores
+// bindFailed itself cannot fail if the bind path never stores it.
+func TestUnhealthyWhenTheListenerNeverBound(t *testing.T) {
+	withCleanState(t)
+
+	// TEST-NET-1, which is not a local address, so the bind cannot succeed.
+	listenAndServe(&sctp.SCTPAddr{
+		IPAddrs: []net.IPAddr{{IP: net.ParseIP("192.0.2.1")}},
+		Port:    38412,
+	}, NGAPHandler{})
+
+	if !bindFailed.Load() {
+		t.Fatal("listenAndServe returned without recording the bind failure")
+	}
+
+	healthy, reason := Healthy()
+	if healthy {
+		t.Errorf("Healthy() = true (%s) after the listener never bound, want false", reason)
+	}
+
+	if reason == "" {
+		t.Error("Healthy() gave no reason for being unhealthy, which is what a probe's logs need")
 	}
 }

--- a/ngap/service/health_test.go
+++ b/ngap/service/health_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"net"
+	"testing"
+)
+
+// withCleanState runs a case against a known listener state and puts back whatever the
+// package held, so the four cases below stay independent of their order.
+func withCleanState(t *testing.T) {
+	t.Helper()
+
+	wasServed, wasShuttingDown := served.Load(), shuttingDown.Load()
+
+	t.Cleanup(func() {
+		served.Store(wasServed)
+		shuttingDown.Store(wasShuttingDown)
+		connections.Range(func(key, _ any) bool {
+			connections.Delete(key)
+			return true
+		})
+	})
+
+	served.Store(false)
+	shuttingDown.Store(false)
+	connections.Range(func(key, _ any) bool {
+		connections.Delete(key)
+		return true
+	})
+}
+
+// A fresh deployment has no associations and is not broken. Reporting it unhealthy would
+// restart it in a loop before any gNB had the chance to connect, and this is also what
+// keeps the signal quiet where the SCTP load balancer holds the associations instead.
+func TestHealthyBeforeAnyAssociationHasBeenServed(t *testing.T) {
+	withCleanState(t)
+
+	if healthy, reason := Healthy(); !healthy {
+		t.Errorf("Healthy() = false (%s) before any association, want true", reason)
+	}
+}
+
+func TestHealthyWhileServing(t *testing.T) {
+	withCleanState(t)
+
+	conn, peer := net.Pipe()
+	defer conn.Close()
+	defer peer.Close()
+
+	served.Store(true)
+	connections.Store(conn, true)
+
+	if healthy, reason := Healthy(); !healthy {
+		t.Errorf("Healthy() = false (%s) while an association is held, want true", reason)
+	}
+}
+
+// The state a process-level check cannot see: up, bound, answering, serving nobody.
+func TestUnhealthyOnceEveryAssociationIsLost(t *testing.T) {
+	withCleanState(t)
+
+	served.Store(true)
+
+	healthy, reason := Healthy()
+	if healthy {
+		t.Error("Healthy() = true after every association was lost, want false")
+	}
+
+	if reason == "" {
+		t.Error("Healthy() gave no reason for being unhealthy, which is what a probe's logs need")
+	}
+}
+
+// Losing every association is what a terminating AMF was asked to do, so it must not read
+// as the fault above — otherwise every rollout restarts the pod it is already replacing.
+func TestHealthyWhileShuttingDown(t *testing.T) {
+	withCleanState(t)
+
+	served.Store(true)
+	shuttingDown.Store(true)
+
+	if healthy, reason := Healthy(); !healthy {
+		t.Errorf("Healthy() = false (%s) during shutdown, want true", reason)
+	}
+}

--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -46,6 +46,11 @@ var (
 	// shuttingDown records that Stop was called, so that an orderly termination closing
 	// its associations does not read as the fault this detects.
 	shuttingDown atomic.Bool
+	// bindFailed records that the listener could not be created at all. Run starts exactly
+	// one listenAndServe and nothing retries it, so the failure is terminal: this AMF will
+	// never serve anyone. Without it such an AMF answers the liveness endpoint exactly as a
+	// healthy one still waiting for its first gNB does.
+	bindFailed atomic.Bool
 )
 
 func setListener(listener *sctp.SCTPListener) {
@@ -120,6 +125,8 @@ func listenAndServe(addr *sctp.SCTPAddr, handler NGAPHandler) {
 	listener, err := sctpConfig.Listen("sctp", addr)
 	if err != nil {
 		logger.NgapLog.Errorf("failed to listen: %+v", err)
+		bindFailed.Store(true)
+
 		return
 	}
 
@@ -267,6 +274,11 @@ func associationCount() int {
 // latches, and so is never reported unhealthy by it.
 func Healthy() (bool, string) {
 	switch {
+	// First, because nothing that follows can make it untrue: an AMF that never bound has
+	// served nobody and never will, which is the same fault as one that has stopped
+	// serving, reached from the other side.
+	case bindFailed.Load():
+		return false, "the NGAP listener never bound"
 	case !served.Load():
 		return true, "no NGAP association has been served yet"
 	case shuttingDown.Load():

--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/ishidawataru/sctp"
@@ -37,6 +38,14 @@ var (
 	// listenerMu guards sctpListener, which listenAndServe writes on the goroutine Run
 	// starts and Stop reads on the goroutine that is terminating the AMF.
 	listenerMu sync.RWMutex
+
+	// served latches when this AMF first accepts an association. It is what makes
+	// "holds none" a different state from "has never held one", and the reason a freshly
+	// deployed AMF that no gNB has reached yet is not reported unhealthy.
+	served atomic.Bool
+	// shuttingDown records that Stop was called, so that an orderly termination closing
+	// its associations does not read as the fault this detects.
+	shuttingDown atomic.Bool
 )
 
 func setListener(listener *sctp.SCTPListener) {
@@ -201,6 +210,7 @@ func listenAndServe(addr *sctp.SCTPAddr, handler NGAPHandler) {
 
 		logger.NgapLog.Infof("[AMF] SCTP Accept from: %+v", newConn.RemoteAddr())
 		connections.Store(newConn, true)
+		served.Store(true)
 		reportAssociationCount()
 
 		go handleConnection(newConn, readBufSize, handler)
@@ -217,17 +227,54 @@ func reportAssociationCount() {
 	countMu.Lock()
 	defer countMu.Unlock()
 
+	metrics.SetNgapAssociations(AssociationCount())
+}
+
+// AssociationCount reports how many SCTP associations this AMF currently terminates.
+func AssociationCount() int {
 	count := 0
 	connections.Range(func(_, _ any) bool {
 		count++
 		return true
 	})
 
-	metrics.SetNgapAssociations(count)
+	return count
+}
+
+// Healthy reports whether this AMF can serve a radio access network, and why not when it
+// cannot.
+//
+// It is false in exactly one case: the AMF has served at least one association and now
+// holds none, with no shutdown requested. That is the state a process-level check cannot
+// see — the AMF is up, its listener is bound, its SBI answers, and nobody is being
+// served, which looks identical to an idle deployment. A restart recovers it, because the
+// radio access network reconnects to whatever is listening.
+//
+// The two exclusions matter as much as the rule. An AMF that has never served is healthy,
+// or a fresh deployment would restart in a loop before any gNB had the chance to connect,
+// and no initial delay can cover a rig that sits deployed for hours first. An AMF that is
+// terminating is healthy, because losing its associations is what it was asked to do.
+//
+// The latch also keeps this quiet where it does not apply: in a deployment whose gNBs
+// connect to the SCTP load balancer, this AMF accepts no associations of its own, never
+// latches, and so is never reported unhealthy by it.
+func Healthy() (bool, string) {
+	switch {
+	case !served.Load():
+		return true, "no NGAP association has been served yet"
+	case shuttingDown.Load():
+		return true, "shutting down"
+	case AssociationCount() == 0:
+		return false, "every NGAP association has been lost"
+	default:
+		return true, "serving"
+	}
 }
 
 func Stop() {
 	logger.NgapLog.Infoln("close SCTP server...")
+
+	shuttingDown.Store(true)
 
 	// The listener is nil if Listen failed, if termination beat the bind, or if Stop has
 	// already run, and Stop runs before the AMF tells its peers it is unavailable, so it

--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/ishidawataru/sctp"
+	"github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/logger"
 	"github.com/omec-project/amf/metrics"
 	"github.com/omec-project/ngap/v2"
@@ -47,9 +48,9 @@ var (
 	// its associations does not read as the fault this detects.
 	shuttingDown atomic.Bool
 	// bindFailed records that the listener could not be created at all. Run starts exactly
-	// one listenAndServe and nothing retries it, so the failure is terminal: this AMF will
-	// never serve anyone. Without it such an AMF answers the liveness endpoint exactly as a
-	// healthy one still waiting for its first gNB does.
+	// one listenAndServe and nothing retries it, so the failure is terminal for this socket.
+	// Whether it is terminal for the *AMF* depends on which path serves gNB traffic, which is
+	// why Healthy consults the deployment mode rather than this flag alone.
 	bindFailed atomic.Bool
 )
 
@@ -277,7 +278,13 @@ func Healthy() (bool, string) {
 	// First, because nothing that follows can make it untrue: an AMF that never bound has
 	// served nobody and never will, which is the same fault as one that has stopped
 	// serving, reached from the other side.
-	case bindFailed.Load():
+	//
+	// Only where this socket is what gNBs reach, though. Run is called unconditionally, so
+	// an AMF fronted by the SCTP load balancer also opens this listener and then never uses
+	// it - associations are terminated by sctplb and reach this AMF over gRPC. Failing that
+	// unused bind says nothing about whether such an AMF can serve, and restarting it for
+	// that would be the false positive this signal exists to avoid.
+	case bindFailed.Load() && !context.AMF_Self().EnableSctpLb:
 		return false, "the NGAP listener never bound"
 	case !served.Load():
 		return true, "no NGAP association has been served yet"

--- a/ngap/service/service.go
+++ b/ngap/service/service.go
@@ -227,11 +227,11 @@ func reportAssociationCount() {
 	countMu.Lock()
 	defer countMu.Unlock()
 
-	metrics.SetNgapAssociations(AssociationCount())
+	metrics.SetNgapAssociations(associationCount())
 }
 
-// AssociationCount reports how many SCTP associations this AMF currently terminates.
-func AssociationCount() int {
+// associationCount reports how many SCTP associations this AMF currently terminates.
+func associationCount() int {
 	count := 0
 	connections.Range(func(_, _ any) bool {
 		count++
@@ -247,8 +247,15 @@ func AssociationCount() int {
 // It is false in exactly one case: the AMF has served at least one association and now
 // holds none, with no shutdown requested. That is the state a process-level check cannot
 // see — the AMF is up, its listener is bound, its SBI answers, and nobody is being
-// served, which looks identical to an idle deployment. A restart recovers it, because the
-// radio access network reconnects to whatever is listening.
+// served, which looks identical to an idle deployment.
+//
+// A restart recovers the element. Whether it recovers service depends on the radio access
+// network re-establishing its association, which not every implementation does, so the
+// value claimed here is that the condition ends visibly rather than that traffic resumes.
+//
+// It also cannot loop: the latch lives in the process, so a restarted AMF has served
+// nothing and reports healthy until a gNB attaches. A RAN that never comes back therefore
+// costs exactly one restart, not a restart every failureThreshold.
 //
 // The two exclusions matter as much as the rule. An AMF that has never served is healthy,
 // or a fresh deployment would restart in a loop before any gNB had the chance to connect,
@@ -264,7 +271,7 @@ func Healthy() (bool, string) {
 		return true, "no NGAP association has been served yet"
 	case shuttingDown.Load():
 		return true, "shutting down"
-	case AssociationCount() == 0:
+	case associationCount() == 0:
 		return false, "every NGAP association has been lost"
 	default:
 		return true, "serving"

--- a/service/init.go
+++ b/service/init.go
@@ -158,6 +158,8 @@ func (amf *AMF) Start() {
 		}
 	}
 
+	metrics.RegisterHealth(ngap_service.Healthy)
+
 	go metrics.InitMetrics()
 
 	if err = metrics.InitialiseKafkaStream(factory.AmfConfig.Configuration); err != nil {


### PR DESCRIPTION
## The state this detects

An AMF that has held NGAP associations and then lost all of them keeps running. Its process is
alive, its listener is still bound, its SBI still answers, and it serves nobody. Nothing it does
distinguishes it from an idle deployment, so an orchestrator has no reason to restart it and an
operator has nothing to look at.

We watched that happen for thirty minutes during a 10 000-UE run: all four SCTP associations died
within 2 ms of each other with `ETIMEDOUT`, the handler goroutines exited, `restartCount` stayed 0,
the pod stayed `Ready`, and `/proc/net/sctp/assocs` was empty. The run appeared to be progressing.

**Stacked on #813**, which adds the association count this reads. That PR is observation only; this
one is the behaviour change, so they are separate. When #813 merges I will rebase this so its diff
shows only its own commit.

## The assertion, and why it is a latch rather than a threshold

`/healthz` answers 503 in exactly one case: the AMF has served at least one association and now
holds none, with no shutdown requested.

The two exclusions carry as much weight as the rule:

- **An AMF that has never served is healthy.** The obvious probe — "zero associations is
  unhealthy" — restarts a fresh deployment in a loop before any gNB has had the chance to connect,
  and no `initialDelaySeconds` covers it, because a deployment can legitimately sit for hours
  before its RAN arrives. What is being detected is a *transition*, so the signal has to remember
  that it once served.
- **An AMF that is terminating is healthy.** Losing every association is what it was asked to do.
  Without this, every rollout would fail the probe on the pod it is already replacing.

The latch also keeps this quiet where it does not apply: in a deployment whose gNBs connect to the
SCTP load balancer, this AMF accepts no associations of its own, so it never latches and can never
be reported unhealthy by this. No configuration switch is needed for that — it falls out of the
rule.

**It cannot loop, either.** The latch lives in the process, so a restarted AMF has served
nothing and reports healthy until a gNB attaches. A radio access network that never comes back
therefore costs exactly one restart, not a restart every `failureThreshold` — which is the first
question this design invites.

## What this signal actually detects, and the trade that comes with it

It detects that **no RAN is attached**, not that the AMF is broken. In a single-gNB deployment
those are the same observation from the outside, but the cause may be entirely RAN-side: a gNB
restart, or a backhaul outage lasting longer than `failureThreshold × periodSeconds`, restarts an
AMF that is working perfectly. That is not free — the restart costs NRF deregistration and
re-registration, the AMF status notifications to the SMF and PCF, and, with `enableDbStore` off,
the in-memory UE contexts.

I think that is the right trade, because the alternative is the state this exists to end: an
element that is up, bound, answering, and serving nobody, indistinguishable from an idle
deployment. But it is a policy decision rather than a bug fix, so it belongs in the description.

**The dwell that keeps it from being twitchy is deliberately the operator's, not mine.**
`failureThreshold × periodSeconds` is exactly a "has been gone this long" timer, it lives where an
operator can see and tune it, and a site with a flaky RAN can raise it. Recording a
"zero since" timestamp inside the check would duplicate that control in a place nobody can
configure, so I have not. If a reviewer would rather have a floor in the process, it is a small
addition and I will make it.

## One limit inherited from what the check reads

- **A silent peer is detected on the kernel's schedule, not the probe's.** The count drops when
  the connection handler's read returns a terminal error. A gNB that shuts down gracefully is
  immediate — that is the 75 s in the table above, which is the probe's own
  `failureThreshold × periodSeconds` and nothing else. A peer that goes away *without* closing
  (a black-holed path, a hard-powered-off node) is noticed only when SCTP heartbeats give up,
  which is minutes at kernel defaults, and the restart follows that. So this bounds how long an
  AMF serves nobody *visibly*, not how fast the loss is seen.
- ~~**A listener that never binds reports healthy for ever.**~~ **Now closed, in a later commit
  on this branch.** `listenAndServe` logged and returned if `Listen` failed, so the count stayed
  0, the latch never armed, and an AMF that could never serve anyone answered 200 — the very
  shape this change exists to end, arrived at from the other side. It was going to be a
  follow-up, on the grounds that the fix belongs where the bind is; it is here instead because it
  is the same requirement, and shipping a liveness signal with a state it cannot express is worse
  than one more commit. `listenAndServe` records the failure, and the check consults it first,
  since nothing later can make it untrue. The test drives `listenAndServe` against a non-local
  address rather than storing the flag, because a test that sets it cannot fail if the bind path
  never does.

## Two edges worth naming

- **A graceful termination has a short window where this can answer 503.** The AMF sends its
  status indication to the RANs *before* `ngap_service.Stop()` runs, and `shuttingDown` is set
  inside `Stop`. A gNB that drops its association the moment it is told can therefore take the
  count to zero a beat before the latch is told a shutdown is in progress, and a probe landing in
  that window sees 503 on a pod that is already going away. The consequence is an `Unhealthy`
  event on a terminating pod rather than anything an operator has to act on, so I have left it
  rather than plumb a second signal through the terminate path — but it is real and worth knowing.
- **The endpoint also appears on the profiling port, when one is configured.**
  `service/init.go` serves `DebugProfilePort` with `http.ListenAndServe(addr, nil)` — the default
  mux — so `/healthz` and the pre-existing `/metrics` are reachable there as well as on `:9089`.
  That is the existing pattern rather than anything this adds, but "no new port is involved" is
  only true of the port I chose, so it is worth being exact.
- **The wiring — that `RegisterHealth` puts the handler at `/healthz` — is covered by the cluster
  run rather than by a unit test.** A test that calls it would register on the default mux and
  mutate global state for every other test in the package, which seemed a worse trade than
  relying on an end-to-end check that actually hit the endpoint over HTTP.

## Why liveness rather than readiness

Readiness gates Service traffic, which means little for an element whose peers arrive over SCTP
rather than through a Service. Liveness restarts, and a restart is the recovery that helps: the
radio access network reconnects to whatever is listening.

## What the restart does and does not buy

It recovers the *element*, not necessarily the *run*. A RAN that does not re-establish its
association — our own load generator is one — will not come back on its own, so the restart ends
the run rather than healing it. That is still the right trade: a run that stops at a known minute
with `restartCount` moving is diagnosable, and one that appears to progress for half an hour is
not. Stated here so nobody reads the first restart as a regression.

## Shape of the change

- `ngap/service` gains the latch (`served`, set where an association is accepted) and
  `shuttingDown` (set by `Stop`), plus `Healthy() (bool, string)` — a reason travels with the
  verdict, because a failing probe is otherwise a bare 503 in the kubelet's events with nothing
  saying which condition fired.
- `metrics` gains `HealthHandler(check)` and `RegisterHealth(check)`, so the endpoint rides the
  mux and port that already serve `/metrics` — no new listener, no new port to open. The check is
  passed in rather than read from `metrics`, which must stay importable from the NGAP layer.
- `service/init.go`, the composition root, wires the two together in one line.

## Verified on a running deployment, not only in tests

An image carrying this and #813 was rolled out to a single-node RKE2 cluster with a UERANSIM gNB
attached, and every state was observed in turn:

| step | `/healthz` | `amf_ngap_associations` | restartCount |
| --- | --- | --- | --- |
| fresh pod, no gNB yet | `200 ok: no NGAP association has been served yet` | 0 | 0 |
| gNB attached, NG Setup done | `200 ok: serving` | 1 (matches `/proc/net/sctp/assocs`) | 0 |
| gNB stopped | **`503`** | 0 | 0 → 1 at t+75s |

With the probe declared (`periodSeconds: 15`, `failureThreshold: 3`), the kubelet reported
`Liveness probe failed: HTTP probe failed with statuscode: 503` and
`Container amf failed liveness probe, will be restarted`, and the container came back. The
never-served case held **with the probe active**, which is the loop this latch exists to prevent.

## Verification

All on linux/amd64, in a container at CI's pinned versions:

- `go build ./...`, `go vet ./...` clean; `go test ./... -race -count=1` ok.
- `golangci-lint run --config .golangci.yml ./...` at **v2.13.2**: 0 issues; `golangci-lint fmt
  --diff` empty.
- `ngap/service/health_test.go` covers all four states — never served, serving, every association
  lost, shutting down — each restoring the package state it touched so the cases stay independent
  of their order.
- `metrics/health_test.go` covers both outcomes of the endpoint: 503 with the reason in the body,
  200 with the reason in the body.

