### PR TITLE
fix(ngap): record a RAN message that names a session with no SM context

### DIFF
--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -26,6 +26,7 @@ type AmfStats struct {
 	ngapMsg           *prometheus.CounterVec
 	gnbSessionProfile *prometheus.GaugeVec
 	dbWriteDropped    prometheus.Counter
+	unknownSmContext  *prometheus.CounterVec
 	ngapAssociations  prometheus.Gauge
 	ngapLastMessage   prometheus.Gauge
 }
@@ -64,6 +65,16 @@ func initAmfStats() *AmfStats {
 				"handled, so a stalled handler behind a live intake still moves it. Exposed " +
 				"as a timestamp rather than an age so that staleness is computed at query time.",
 		}),
+
+		unknownSmContext: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "amf_ngap_unknown_sm_context_total",
+			Help: "PDU sessions named by a RAN message for which this AMF held no SM context. " +
+				"Counted per session rather than per message, because one message can name " +
+				"several and only some may be unresolvable. The label is 'message' rather " +
+				"than 'msg_type' on purpose: it carries the specific NGAP message, where " +
+				"ngap_messages_total's msg_type carries procedure names and cannot " +
+				"distinguish a UEContextReleaseComplete from a UEContextReleaseRequest.",
+		}, []string{"message"}),
 	}
 }
 
@@ -86,6 +97,10 @@ func (ps *AmfStats) register() error {
 	}
 	prometheus.Unregister(ps.ngapLastMessage)
 	if err := prometheus.Register(ps.ngapLastMessage); err != nil {
+		return err
+	}
+	prometheus.Unregister(ps.unknownSmContext)
+	if err := prometheus.Register(ps.unknownSmContext); err != nil {
 		return err
 	}
 	return nil
@@ -149,6 +164,12 @@ func SetNgapAssociations(count int) {
 // telling apart.
 func SetNgapLastMessage() {
 	amfStats.ngapLastMessage.SetToCurrentTime()
+}
+
+// IncrementUnknownSmContext counts one PDU session that a RAN message named and this AMF could
+// not resolve to an SM context.
+func IncrementUnknownSmContext(message string) {
+	amfStats.unknownSmContext.WithLabelValues(sanitizeLabelValue(message)).Inc()
 }
 
 // IncrementDbWriteDropped increments the counter of UE context writes dropped

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -63,6 +63,11 @@ func findRanUeByAmfNgapID(ran *context.AmfRan, aMFUENGAPID *ngapType.AMFUENGAPID
 // says how often and for which message, and the log line names the UE and the session. A RAN
 // holding a tunnel and an SMF holding a pending session are then both findable, which is what
 // this element can honestly offer.
+//
+// A caller must not carry on to the session management function with the context it just failed
+// to find: SendUpdateSmContextRequest reads the SMF's URI out of it while opening its trace
+// span, before it builds anything, so a nil one ends the process rather than the message. No
+// caller does.
 func recordUnknownSmContext(ranUe *context.RanUe, message string, pduSessionID int32) {
 	metrics.IncrementUnknownSmContext(message)
 
@@ -2029,6 +2034,7 @@ func HandlePDUSessionResourceModifyResponse(ctx ctxt.Context, ran *context.AmfRa
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
 					recordUnknownSmContext(ranUe, "PDUSessionResourceModifyResponse", pduSessionID)
+					continue
 				}
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 					models.N2SMINFOTYPE_PDU_RES_MOD_RSP, transfer)
@@ -2052,6 +2058,7 @@ func HandlePDUSessionResourceModifyResponse(ctx ctxt.Context, ran *context.AmfRa
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
 					recordUnknownSmContext(ranUe, "PDUSessionResourceModifyResponse", pduSessionID)
+					continue
 				}
 				// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2174,6 +2181,7 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
 			recordUnknownSmContext(ranUe, "PDUSessionResourceNotify", pduSessionID)
+			continue
 		}
 		response, errResponse, problemDetail, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 			models.N2SMINFOTYPE_PDU_RES_NTY, transfer)
@@ -2238,6 +2246,7 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
 				recordUnknownSmContext(ranUe, "PDUSessionResourceNotify", pduSessionID)
+				continue
 			}
 			response, errResponse, problemDetail, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PDU_RES_NTY_REL, transfer)
@@ -3184,6 +3193,7 @@ func HandleHandoverNotify(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionid)
 			if !ok {
 				recordUnknownSmContext(sourceUe, "HandoverNotify", pduSessionid)
+				continue
 			}
 			_, _, _, err := consumer.SendUpdateSmContextN2HandoverComplete(ctx, amfUe, smContext, "", nil)
 			if err != nil {
@@ -3327,6 +3337,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
 				recordUnknownSmContext(ranUe, "PathSwitchRequest", pduSessionID)
+				continue
 			}
 			response, errResponse, _, err := consumer.SendUpdateSmContextXnHandover(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PATH_SWITCH_REQ, transfer)
@@ -3364,6 +3375,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
 				recordUnknownSmContext(ranUe, "PathSwitchRequest", pduSessionID)
+				continue
 			}
 			response, errResponse, _, err := consumer.SendUpdateSmContextXnHandoverFailed(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PATH_SWITCH_SETUP_FAIL, transfer)

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -2525,7 +2525,7 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
 				recordUnknownSmContext(ranUe, "InitialContextSetupResponse", pduSessionID)
-				return
+				continue
 			}
 			// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
 			response, errResponse, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2564,7 +2564,7 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
 				recordUnknownSmContext(ranUe, "InitialContextSetupResponse", pduSessionID)
-				return
+				continue
 			}
 			// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
 			_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -3530,36 +3530,40 @@ func HandleHandoverRequestAcknowledge(ctx ctxt.Context, ran *context.AmfRan, mes
 			pduSessionID := item.PDUSessionID.Value
 			transfer := item.HandoverRequestAcknowledgeTransfer
 			pduSessionId := int32(pduSessionID)
-			if smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId); exist {
-				response, errResponse, problemDetails, err := consumer.SendUpdateSmContextN2HandoverPrepared(ctx, amfUe,
-					smContext, models.N2SMINFOTYPE_HANDOVER_REQ_ACK, transfer)
+			smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId)
+			if !exist {
+				recordUnknownSmContext(targetUe, "HandoverRequestAcknowledge", pduSessionId)
+				continue
+			}
+
+			response, errResponse, problemDetails, err := consumer.SendUpdateSmContextN2HandoverPrepared(ctx, amfUe,
+				smContext, models.N2SMINFOTYPE_HANDOVER_REQ_ACK, transfer)
+			if err != nil {
+				targetUe.Log.Errorf("send HandoverRequestAcknowledgeTransfer error: %v", err)
+			}
+			if problemDetails != nil {
+				targetUe.Log.Warnf("ProblemDetails[status: %d, Cause: %s]", problemDetails.GetStatus(), problemDetails.GetCause())
+			}
+			if response != nil && response.GetBinaryDataN2SmInformation() != nil {
+				handoverItem := ngapType.PDUSessionResourceHandoverItem{}
+				handoverItem.PDUSessionID = item.PDUSessionID
+				binaryDataN2SmInformation, err := util.ReadAndCleanupBinaryTempFile(response.GetBinaryDataN2SmInformation())
 				if err != nil {
-					targetUe.Log.Errorf("send HandoverRequestAcknowledgeTransfer error: %v", err)
+					targetUe.Log.Errorf("readAll from response.BinaryDataN2SmInformation error: %v", err)
 				}
-				if problemDetails != nil {
-					targetUe.Log.Warnf("ProblemDetails[status: %d, Cause: %s]", problemDetails.GetStatus(), problemDetails.GetCause())
+				handoverItem.HandoverCommandTransfer = binaryDataN2SmInformation
+				pduSessionResourceHandoverList.List = append(pduSessionResourceHandoverList.List, handoverItem)
+				targetUe.SuccessPduSessionId = append(targetUe.SuccessPduSessionId, pduSessionId)
+			}
+			if errResponse != nil && errResponse.GetBinaryDataN2SmInformation() != nil {
+				releaseItem := ngapType.PDUSessionResourceToReleaseItemHOCmd{}
+				releaseItem.PDUSessionID = item.PDUSessionID
+				binaryDataN2SmInformation, err := util.ReadAndCleanupBinaryTempFile(errResponse.GetBinaryDataN2SmInformation())
+				if err != nil {
+					targetUe.Log.Errorf("readAll from errResponse.BinaryDataN2SmInformation error: %v", err)
 				}
-				if response != nil && response.GetBinaryDataN2SmInformation() != nil {
-					handoverItem := ngapType.PDUSessionResourceHandoverItem{}
-					handoverItem.PDUSessionID = item.PDUSessionID
-					binaryDataN2SmInformation, err := util.ReadAndCleanupBinaryTempFile(response.GetBinaryDataN2SmInformation())
-					if err != nil {
-						targetUe.Log.Errorf("readAll from response.BinaryDataN2SmInformation error: %v", err)
-					}
-					handoverItem.HandoverCommandTransfer = binaryDataN2SmInformation
-					pduSessionResourceHandoverList.List = append(pduSessionResourceHandoverList.List, handoverItem)
-					targetUe.SuccessPduSessionId = append(targetUe.SuccessPduSessionId, pduSessionId)
-				}
-				if errResponse != nil && errResponse.GetBinaryDataN2SmInformation() != nil {
-					releaseItem := ngapType.PDUSessionResourceToReleaseItemHOCmd{}
-					releaseItem.PDUSessionID = item.PDUSessionID
-					binaryDataN2SmInformation, err := util.ReadAndCleanupBinaryTempFile(errResponse.GetBinaryDataN2SmInformation())
-					if err != nil {
-						targetUe.Log.Errorf("readAll from errResponse.BinaryDataN2SmInformation error: %v", err)
-					}
-					releaseItem.HandoverPreparationUnsuccessfulTransfer = binaryDataN2SmInformation
-					pduSessionResourceToReleaseList.List = append(pduSessionResourceToReleaseList.List, releaseItem)
-				}
+				releaseItem.HandoverPreparationUnsuccessfulTransfer = binaryDataN2SmInformation
+				pduSessionResourceToReleaseList.List = append(pduSessionResourceToReleaseList.List, releaseItem)
 			}
 		}
 	}
@@ -3569,15 +3573,19 @@ func HandleHandoverRequestAcknowledge(ctx ctxt.Context, ran *context.AmfRan, mes
 			pduSessionID := item.PDUSessionID.Value
 			transfer := item.HandoverResourceAllocationUnsuccessfulTransfer
 			pduSessionId := int32(pduSessionID)
-			if smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId); exist {
-				_, _, problemDetails, err := consumer.SendUpdateSmContextN2HandoverPrepared(ctx, amfUe, smContext,
-					models.N2SMINFOTYPE_HANDOVER_RES_ALLOC_FAIL, transfer)
-				if err != nil {
-					targetUe.Log.Errorf("Send HandoverResourceAllocationUnsuccessfulTransfer error: %v", err)
-				}
-				if problemDetails != nil {
-					targetUe.Log.Warnf("ProblemDetails[status: %d, Cause: %s]", problemDetails.Status, problemDetails.Cause)
-				}
+			smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId)
+			if !exist {
+				recordUnknownSmContext(targetUe, "HandoverRequestAcknowledge", pduSessionId)
+				continue
+			}
+
+			_, _, problemDetails, err := consumer.SendUpdateSmContextN2HandoverPrepared(ctx, amfUe, smContext,
+				models.N2SMINFOTYPE_HANDOVER_RES_ALLOC_FAIL, transfer)
+			if err != nil {
+				targetUe.Log.Errorf("Send HandoverResourceAllocationUnsuccessfulTransfer error: %v", err)
+			}
+			if problemDetails != nil {
+				targetUe.Log.Warnf("ProblemDetails[status: %d, Cause: %s]", problemDetails.Status, problemDetails.Cause)
 			}
 		}
 	}
@@ -3884,23 +3892,27 @@ func HandleHandoverRequired(ctx ctxt.Context, ran *context.AmfRan, message *ngap
 		var pduSessionReqList ngapType.PDUSessionResourceSetupListHOReq
 		for _, pDUSessionResourceHoItem := range pDUSessionResourceListHORqd.List {
 			pduSessionId := int32(pDUSessionResourceHoItem.PDUSessionID.Value)
-			if smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId); exist {
-				response, _, _, err := consumer.SendUpdateSmContextN2HandoverPreparing(ctx, amfUe, smContext,
-					models.N2SMINFOTYPE_HANDOVER_REQUIRED, pDUSessionResourceHoItem.HandoverRequiredTransfer, "", &targetId)
+			smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionId)
+			if !exist {
+				recordUnknownSmContext(sourceUe, "HandoverRequired", pduSessionId)
+				continue
+			}
+
+			response, _, _, err := consumer.SendUpdateSmContextN2HandoverPreparing(ctx, amfUe, smContext,
+				models.N2SMINFOTYPE_HANDOVER_REQUIRED, pDUSessionResourceHoItem.HandoverRequiredTransfer, "", &targetId)
+			if err != nil {
+				sourceUe.Log.Errorf("consumer.SendUpdateSmContextN2HandoverPreparing Error: %+v", err)
+			}
+			if response == nil {
+				sourceUe.Log.Errorf("SendUpdateSmContextN2HandoverPreparing Error for PduSessionId[%d]", pduSessionId)
+				continue
+			} else if response.GetBinaryDataN2SmInformation() != nil {
+				binaryData, err := util.ReadAndCleanupBinaryTempFile(response.GetBinaryDataN2SmInformation())
 				if err != nil {
-					sourceUe.Log.Errorf("consumer.SendUpdateSmContextN2HandoverPreparing Error: %+v", err)
+					sourceUe.Log.Errorf("readAll from response.BinaryDataN2SmInformation error: %v", err)
 				}
-				if response == nil {
-					sourceUe.Log.Errorf("SendUpdateSmContextN2HandoverPreparing Error for PduSessionId[%d]", pduSessionId)
-					continue
-				} else if response.GetBinaryDataN2SmInformation() != nil {
-					binaryData, err := util.ReadAndCleanupBinaryTempFile(response.GetBinaryDataN2SmInformation())
-					if err != nil {
-						sourceUe.Log.Errorf("readAll from response.BinaryDataN2SmInformation error: %v", err)
-					}
-					ngap_message.AppendPDUSessionResourceSetupListHOReq(&pduSessionReqList, pduSessionId,
-						smContext.Snssai(), binaryData)
-				}
+				ngap_message.AppendPDUSessionResourceSetupListHOReq(&pduSessionReqList, pduSessionId,
+					smContext.Snssai(), binaryData)
 			}
 		}
 		if len(pduSessionReqList.List) == 0 {

--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -48,6 +48,34 @@ func findRanUeByAmfNgapID(ran *context.AmfRan, aMFUENGAPID *ngapType.AMFUENGAPID
 	return context.AMF_Self().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
 }
 
+// recordUnknownSmContext records a RAN message that named a PDU session this AMF holds no SM
+// context for. Every place in this file that reaches that condition comes through here, so that
+// what the AMF does about it is decided once.
+//
+// It deliberately does not try to resolve the condition, because neither route is open. The
+// session management function cannot be told: its URI lives in the SM context that is missing.
+// And the session cannot be released RAN-side by this element alone: TS 38.413 clause 9.2.1.3
+// carries the PDU Session Resource Release Command Transfer as mandatory in that message, and
+// clause 9.3.4.12 declares that IE transparent to the AMF - so the AMF relays one the SMF
+// authored rather than writing its own.
+//
+// So the obligation is to leave the condition discoverable instead of dropping it: the counter
+// says how often and for which message, and the log line names the UE and the session. A RAN
+// holding a tunnel and an SMF holding a pending session are then both findable, which is what
+// this element can honestly offer.
+func recordUnknownSmContext(ranUe *context.RanUe, message string, pduSessionID int32) {
+	metrics.IncrementUnknownSmContext(message)
+
+	// Nil-safe on purpose: this function exists because a missing pointer was dropped silently,
+	// and it must not become a second one.
+	log := logger.NgapLog
+	if ranUe != nil && ranUe.Log != nil {
+		log = ranUe.Log
+	}
+
+	log.Errorf("SmContext[PDU Session ID:%d] not found, named by %s", pduSessionID, message)
+}
+
 func FetchRanUeContext(ran *context.AmfRan, message *ngapType.NGAPPDU) (*context.RanUe, *ngapType.AMFUENGAPID) {
 	amfSelf := context.AMF_Self()
 
@@ -1161,7 +1189,7 @@ func HandleUEContextReleaseComplete(ctx ctxt.Context, ran *context.AmfRan, messa
 					pduSessionID := int32(pduSessionReourceItem.PDUSessionID.Value)
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+						recordUnknownSmContext(ranUe, "UEContextReleaseComplete", pduSessionID)
 						continue
 					}
 					response, _, _, err := consumer.SendUpdateSmContextDeactivateUpCnxState(ctx, amfUe, smContext, cause)
@@ -1340,7 +1368,7 @@ func HandlePDUSessionResourceReleaseResponse(ctx ctxt.Context, ran *context.AmfR
 			transfer := item.PDUSessionResourceReleaseResponseTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "PDUSessionResourceReleaseResponse", pduSessionID)
 				continue
 			}
 			_, responseErr, problemDetail, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -1830,7 +1858,7 @@ func HandlePDUSessionResourceSetupResponse(ctx ctxt.Context, ran *context.AmfRan
 				transfer := item.PDUSessionResourceSetupResponseTransfer
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
-					ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+					recordUnknownSmContext(ranUe, "PDUSessionResourceSetupResponse", pduSessionID)
 					continue
 				}
 				response, errResponse, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -1868,7 +1896,7 @@ func HandlePDUSessionResourceSetupResponse(ctx ctxt.Context, ran *context.AmfRan
 				transfer := item.PDUSessionResourceSetupUnsuccessfulTransfer
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
-					ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+					recordUnknownSmContext(ranUe, "PDUSessionResourceSetupResponse", pduSessionID)
 					continue
 				}
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2000,7 +2028,7 @@ func HandlePDUSessionResourceModifyResponse(ctx ctxt.Context, ran *context.AmfRa
 				transfer := item.PDUSessionResourceModifyResponseTransfer
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
-					ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+					recordUnknownSmContext(ranUe, "PDUSessionResourceModifyResponse", pduSessionID)
 				}
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 					models.N2SMINFOTYPE_PDU_RES_MOD_RSP, transfer)
@@ -2023,7 +2051,7 @@ func HandlePDUSessionResourceModifyResponse(ctx ctxt.Context, ran *context.AmfRa
 				transfer := item.PDUSessionResourceModifyUnsuccessfulTransfer
 				smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 				if !ok {
-					ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+					recordUnknownSmContext(ranUe, "PDUSessionResourceModifyResponse", pduSessionID)
 				}
 				// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
 				_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2145,7 +2173,7 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 		transfer := item.PDUSessionResourceNotifyTransfer
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+			recordUnknownSmContext(ranUe, "PDUSessionResourceNotify", pduSessionID)
 		}
 		response, errResponse, problemDetail, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 			models.N2SMINFOTYPE_PDU_RES_NTY, transfer)
@@ -2209,7 +2237,7 @@ func HandlePDUSessionResourceNotify(ctx ctxt.Context, ran *context.AmfRan, messa
 			transfer := item.PDUSessionResourceNotifyReleasedTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "PDUSessionResourceNotify", pduSessionID)
 			}
 			response, errResponse, problemDetail, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PDU_RES_NTY_REL, transfer)
@@ -2371,7 +2399,7 @@ func HandlePDUSessionResourceModifyIndication(ctx ctxt.Context, ran *context.Amf
 		transfer := item.PDUSessionResourceModifyIndicationTransfer
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+			recordUnknownSmContext(ranUe, "PDUSessionResourceModifyIndication", pduSessionID)
 			continue
 		}
 		response, errResponse, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2487,7 +2515,7 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 			transfer := item.PDUSessionResourceSetupResponseTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "InitialContextSetupResponse", pduSessionID)
 				return
 			}
 			// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
@@ -2526,7 +2554,7 @@ func HandleInitialContextSetupResponse(ctx ctxt.Context, ran *context.AmfRan, me
 			transfer := item.PDUSessionResourceSetupUnsuccessfulTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "InitialContextSetupResponse", pduSessionID)
 				return
 			}
 			// response, _, _, err := consumer.SendUpdateSmContextN2Info(amfUe, pduSessionID,
@@ -2651,7 +2679,10 @@ func HandleInitialContextSetupFailure(ctx ctxt.Context, ran *context.AmfRan, mes
 			transfer := item.PDUSessionResourceSetupUnsuccessfulTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found. No need to send UpdateSmContext message to SMF", pduSessionID)
+				// Expected here rather than a fault: the context setup failed, so there
+				// is no established session to reconcile and nothing to tell the SMF.
+				// Counted under this message so it can be excluded from an alert.
+				recordUnknownSmContext(ranUe, "InitialContextSetupFailure", pduSessionID)
 				continue
 			}
 			_, _, _, err := consumer.SendUpdateSmContextN2Info(ctx, amfUe, smContext,
@@ -2766,7 +2797,7 @@ func HandleUEContextReleaseRequest(ctx ctxt.Context, ran *context.AmfRan, messag
 					pduSessionID := int32(pduSessionReourceItem.PDUSessionID.Value)
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+						recordUnknownSmContext(ranUe, "UEContextReleaseRequest", pduSessionID)
 						continue
 					}
 					response, _, _, err := consumer.SendUpdateSmContextDeactivateUpCnxState(ctx, amfUe, smContext, causeAll)
@@ -3152,7 +3183,7 @@ func HandleHandoverNotify(ctx ctxt.Context, ran *context.AmfRan, message *ngapTy
 		for _, pduSessionid := range targetUe.SuccessPduSessionId {
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionid)
 			if !ok {
-				sourceUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionid)
+				recordUnknownSmContext(sourceUe, "HandoverNotify", pduSessionid)
 			}
 			_, _, _, err := consumer.SendUpdateSmContextN2HandoverComplete(ctx, amfUe, smContext, "", nil)
 			if err != nil {
@@ -3295,7 +3326,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 			transfer := item.PathSwitchRequestTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "PathSwitchRequest", pduSessionID)
 			}
 			response, errResponse, _, err := consumer.SendUpdateSmContextXnHandover(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PATH_SWITCH_REQ, transfer)
@@ -3332,7 +3363,7 @@ func HandlePathSwitchRequest(ctx ctxt.Context, ran *context.AmfRan, message *nga
 			transfer := item.PathSwitchRequestSetupFailedTransfer
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				ranUe.Log.Errorf("SmContext[PDU Session ID: %d] not found", pduSessionID)
+				recordUnknownSmContext(ranUe, "PathSwitchRequest", pduSessionID)
 			}
 			response, errResponse, _, err := consumer.SendUpdateSmContextXnHandoverFailed(ctx, amfUe, smContext,
 				models.N2SMINFOTYPE_PATH_SWITCH_SETUP_FAIL, transfer)

--- a/ngap/unknown_sm_context_test.go
+++ b/ngap/unknown_sm_context_test.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package ngap
+
+import (
+	ctxt "context"
+	"testing"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/ngap/v2/ngapType"
+	"github.com/omec-project/openapi/v2/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// unknownSmContextCount reads one label's value out of the default registry. The gathered types
+// are used through their accessors only, so this needs no new module dependency.
+func unknownSmContextCount(t *testing.T, message string) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather() = %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "amf_ngap_unknown_sm_context_total" {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "message" && label.GetValue() == message {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+func setupResponseNaming(ranUe *context.RanUe, pduSessionIDs ...int64) *ngapType.NGAPPDU {
+	list := ngapType.PDUSessionResourceSetupListSURes{}
+	for _, id := range pduSessionIDs {
+		list.List = append(list.List, ngapType.PDUSessionResourceSetupItemSURes{
+			PDUSessionID:                            ngapType.PDUSessionID{Value: id},
+			PDUSessionResourceSetupResponseTransfer: []byte{},
+		})
+	}
+
+	return &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentSuccessfulOutcome,
+		SuccessfulOutcome: &ngapType.SuccessfulOutcome{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodePDUSessionResourceSetup},
+			Value: ngapType.SuccessfulOutcomeValue{
+				Present: ngapType.SuccessfulOutcomePresentPDUSessionResourceSetup,
+				PDUSessionResourceSetup: &ngapType.PDUSessionResourceSetupResponse{
+					ProtocolIEs: ngapType.ProtocolIEContainerPDUSessionResourceSetupResponseIEs{
+						List: []ngapType.PDUSessionResourceSetupResponseIEs{
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDAMFUENGAPID},
+								Value: ngapType.PDUSessionResourceSetupResponseIEsValue{
+									Present:     ngapType.PDUSessionResourceSetupResponseIEsPresentAMFUENGAPID,
+									AMFUENGAPID: &ngapType.AMFUENGAPID{Value: ranUe.AmfUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDRANUENGAPID},
+								Value: ngapType.PDUSessionResourceSetupResponseIEsValue{
+									Present:     ngapType.PDUSessionResourceSetupResponseIEsPresentRANUENGAPID,
+									RANUENGAPID: &ngapType.RANUENGAPID{Value: ranUe.RanUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDPDUSessionResourceSetupListSURes},
+								Value: ngapType.PDUSessionResourceSetupResponseIEsValue{
+									Present:                          ngapType.PDUSessionResourceSetupResponseIEsPresentPDUSessionResourceSetupListSURes,
+									PDUSessionResourceSetupListSURes: &list,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// The unit of this defect is the session, not the message: one setup response can name several
+// PDU sessions and only some of them may be unresolvable. A counter incremented per message
+// could not express "two of the sessions in this message were stranded", which is why this is
+// its own metric rather than a result label on ngap_messages_total.
+func TestSetupResponseCountsSessionsRatherThanMessages(t *testing.T) {
+	self := context.AMF_Self()
+
+	ran := context.NewAmfRanDefault()
+	ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
+
+	ranUe, err := ran.NewRanUe(701)
+	if err != nil {
+		t.Fatalf("NewRanUe() = %v", err)
+	}
+	ranUe.Log = logger.NgapLog
+
+	amfUe := self.NewAmfUe("")
+	amfUe.AttachRanUe(ranUe)
+
+	before := unknownSmContextCount(t, "PDUSessionResourceSetupResponse")
+
+	// Two sessions, neither of which this AMF has an SM context for.
+	HandlePDUSessionResourceSetupResponse(ctxt.Background(), ran, setupResponseNaming(ranUe, 1, 2))
+
+	if got := unknownSmContextCount(t, "PDUSessionResourceSetupResponse") - before; got != 2 {
+		t.Errorf("counter rose by %v for one message naming two unresolvable sessions, want 2", got)
+	}
+}
+
+// The condition being recorded is a missing pointer that used to be dropped silently. The
+// recording must not become a second one.
+func TestRecordUnknownSmContextSurvivesANilRanUe(t *testing.T) {
+	before := unknownSmContextCount(t, "PathSwitchRequest")
+
+	recordUnknownSmContext(nil, "PathSwitchRequest", 9)
+
+	if got := unknownSmContextCount(t, "PathSwitchRequest") - before; got != 1 {
+		t.Errorf("counter rose by %v with a nil RanUe, want 1", got)
+	}
+}
+
+func releaseResponseNaming(ranUe *context.RanUe, pduSessionID int64) *ngapType.NGAPPDU {
+	list := ngapType.PDUSessionResourceReleasedListRelRes{
+		List: []ngapType.PDUSessionResourceReleasedItemRelRes{
+			{
+				PDUSessionID: ngapType.PDUSessionID{Value: pduSessionID},
+				PDUSessionResourceReleaseResponseTransfer: []byte{},
+			},
+		},
+	}
+
+	return &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentSuccessfulOutcome,
+		SuccessfulOutcome: &ngapType.SuccessfulOutcome{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodePDUSessionResourceRelease},
+			Value: ngapType.SuccessfulOutcomeValue{
+				Present: ngapType.SuccessfulOutcomePresentPDUSessionResourceRelease,
+				PDUSessionResourceRelease: &ngapType.PDUSessionResourceReleaseResponse{
+					ProtocolIEs: ngapType.ProtocolIEContainerPDUSessionResourceReleaseResponseIEs{
+						List: []ngapType.PDUSessionResourceReleaseResponseIEs{
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDAMFUENGAPID},
+								Value: ngapType.PDUSessionResourceReleaseResponseIEsValue{
+									Present:     ngapType.PDUSessionResourceReleaseResponseIEsPresentAMFUENGAPID,
+									AMFUENGAPID: &ngapType.AMFUENGAPID{Value: ranUe.AmfUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDRANUENGAPID},
+								Value: ngapType.PDUSessionResourceReleaseResponseIEsValue{
+									Present:     ngapType.PDUSessionResourceReleaseResponseIEsPresentRANUENGAPID,
+									RANUENGAPID: &ngapType.RANUENGAPID{Value: ranUe.RanUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDPDUSessionResourceReleasedListRelRes},
+								Value: ngapType.PDUSessionResourceReleaseResponseIEsValue{
+									Present:                              ngapType.PDUSessionResourceReleaseResponseIEsPresentPDUSessionResourceReleasedListRelRes,
+									PDUSessionResourceReleasedListRelRes: &list,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// The release shape owes the opposite of the setup shape: here the RAN has already let the
+// session go, so what must be discoverable is an SMF still holding one. Driving the handler
+// rather than the recorder is the point — the defect was that this path reached no recorder
+// at all.
+func TestReleaseResponseIdentifiesASessionTheAmfCannotResolve(t *testing.T) {
+	self := context.AMF_Self()
+
+	ran := context.NewAmfRanDefault()
+	ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
+
+	ranUe, err := ran.NewRanUe(702)
+	if err != nil {
+		t.Fatalf("NewRanUe() = %v", err)
+	}
+	ranUe.Log = logger.NgapLog
+
+	amfUe := self.NewAmfUe("")
+	amfUe.AttachRanUe(ranUe)
+
+	before := unknownSmContextCount(t, "PDUSessionResourceReleaseResponse")
+
+	HandlePDUSessionResourceReleaseResponse(ctxt.Background(), ran, releaseResponseNaming(ranUe, 5))
+
+	if got := unknownSmContextCount(t, "PDUSessionResourceReleaseResponse") - before; got != 1 {
+		t.Errorf("counter rose by %v for a release response naming one unresolvable session, want 1", got)
+	}
+}

--- a/ngap/unknown_sm_context_test.go
+++ b/ngap/unknown_sm_context_test.go
@@ -107,6 +107,17 @@ func TestSetupResponseCountsSessionsRatherThanMessages(t *testing.T) {
 	amfUe := self.NewAmfUe("")
 	amfUe.AttachRanUe(ranUe)
 
+	// The pools are global to the package, so what this test creates has to leave with it -
+	// both the RanUe and its AMF UE NGAP ID, which the generator would otherwise keep issued.
+	t.Cleanup(func() {
+		if leftover := self.RanUeFindByAmfUeNgapIDLocal(ranUe.AmfUeNgapId); leftover != nil {
+			if err := leftover.Remove(); err != nil {
+				t.Errorf("cleanup RanUe failed: %v", err)
+			}
+		}
+		amfUe.Remove()
+	})
+
 	before := unknownSmContextCount(t, "PDUSessionResourceSetupResponse")
 
 	// Two sessions, neither of which this AMF has an SM context for.
@@ -177,8 +188,8 @@ func releaseResponseNaming(ranUe *context.RanUe, pduSessionID int64) *ngapType.N
 	}
 }
 
-// The release shape owes the opposite of the setup shape: here the RAN has already let the
-// session go, so what must be discoverable is an SMF still holding one. Driving the handler
+// The release shape has the opposite consequence to the setup shape: here the RAN has
+// already let the session go, so what must be discoverable is an SMF still holding one. Driving the handler
 // rather than the recorder is the point — the defect was that this path reached no recorder
 // at all.
 func TestReleaseResponseIdentifiesASessionTheAmfCannotResolve(t *testing.T) {
@@ -195,6 +206,17 @@ func TestReleaseResponseIdentifiesASessionTheAmfCannotResolve(t *testing.T) {
 
 	amfUe := self.NewAmfUe("")
 	amfUe.AttachRanUe(ranUe)
+
+	// The pools are global to the package, so what this test creates has to leave with it -
+	// both the RanUe and its AMF UE NGAP ID, which the generator would otherwise keep issued.
+	t.Cleanup(func() {
+		if leftover := self.RanUeFindByAmfUeNgapIDLocal(ranUe.AmfUeNgapId); leftover != nil {
+			if err := leftover.Remove(); err != nil {
+				t.Errorf("cleanup RanUe failed: %v", err)
+			}
+		}
+		amfUe.Remove()
+	})
 
 	before := unknownSmContextCount(t, "PDUSessionResourceReleaseResponse")
 
@@ -272,6 +294,17 @@ func TestNotifyForAnUnresolvableSessionDoesNotEndTheProcess(t *testing.T) {
 
 	amfUe := self.NewAmfUe("")
 	amfUe.AttachRanUe(ranUe)
+
+	// The pools are global to the package, so what this test creates has to leave with it -
+	// both the RanUe and its AMF UE NGAP ID, which the generator would otherwise keep issued.
+	t.Cleanup(func() {
+		if leftover := self.RanUeFindByAmfUeNgapIDLocal(ranUe.AmfUeNgapId); leftover != nil {
+			if err := leftover.Remove(); err != nil {
+				t.Errorf("cleanup RanUe failed: %v", err)
+			}
+		}
+		amfUe.Remove()
+	})
 
 	before := unknownSmContextCount(t, "PDUSessionResourceNotify")
 

--- a/ngap/unknown_sm_context_test.go
+++ b/ngap/unknown_sm_context_test.go
@@ -93,6 +93,8 @@ func setupResponseNaming(ranUe *context.RanUe, pduSessionIDs ...int64) *ngapType
 // could not express "two of the sessions in this message were stranded", which is why this is
 // its own metric rather than a result label on ngap_messages_total.
 func TestSetupResponseCountsSessionsRatherThanMessages(t *testing.T) {
+	disableKafkaForTest(t)
+
 	self := context.AMF_Self()
 
 	ran := context.NewAmfRanDefault()
@@ -193,6 +195,8 @@ func releaseResponseNaming(ranUe *context.RanUe, pduSessionID int64) *ngapType.N
 // rather than the recorder is the point — the defect was that this path reached no recorder
 // at all.
 func TestReleaseResponseIdentifiesASessionTheAmfCannotResolve(t *testing.T) {
+	disableKafkaForTest(t)
+
 	self := context.AMF_Self()
 
 	ran := context.NewAmfRanDefault()
@@ -281,6 +285,8 @@ func notifyNaming(ranUe *context.RanUe, pduSessionID int64) *ngapType.NGAPPDU {
 // recover(), which means every UE on every gNB, not just this session. The recording is worth
 // little if the AMF does not survive to be scraped.
 func TestNotifyForAnUnresolvableSessionDoesNotEndTheProcess(t *testing.T) {
+	disableKafkaForTest(t)
+
 	self := context.AMF_Self()
 
 	ran := context.NewAmfRanDefault()

--- a/ngap/unknown_sm_context_test.go
+++ b/ngap/unknown_sm_context_test.go
@@ -204,3 +204,82 @@ func TestReleaseResponseIdentifiesASessionTheAmfCannotResolve(t *testing.T) {
 		t.Errorf("counter rose by %v for a release response naming one unresolvable session, want 1", got)
 	}
 }
+
+func notifyNaming(ranUe *context.RanUe, pduSessionID int64) *ngapType.NGAPPDU {
+	list := ngapType.PDUSessionResourceNotifyList{
+		List: []ngapType.PDUSessionResourceNotifyItem{
+			{
+				PDUSessionID:                     ngapType.PDUSessionID{Value: pduSessionID},
+				PDUSessionResourceNotifyTransfer: []byte{},
+			},
+		},
+	}
+
+	return &ngapType.NGAPPDU{
+		Present: ngapType.NGAPPDUPresentInitiatingMessage,
+		InitiatingMessage: &ngapType.InitiatingMessage{
+			ProcedureCode: ngapType.ProcedureCode{Value: ngapType.ProcedureCodePDUSessionResourceNotify},
+			Value: ngapType.InitiatingMessageValue{
+				Present: ngapType.InitiatingMessagePresentPDUSessionResourceNotify,
+				PDUSessionResourceNotify: &ngapType.PDUSessionResourceNotify{
+					ProtocolIEs: ngapType.ProtocolIEContainerPDUSessionResourceNotifyIEs{
+						List: []ngapType.PDUSessionResourceNotifyIEs{
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDAMFUENGAPID},
+								Value: ngapType.PDUSessionResourceNotifyIEsValue{
+									Present:     ngapType.PDUSessionResourceNotifyIEsPresentAMFUENGAPID,
+									AMFUENGAPID: &ngapType.AMFUENGAPID{Value: ranUe.AmfUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDRANUENGAPID},
+								Value: ngapType.PDUSessionResourceNotifyIEsValue{
+									Present:     ngapType.PDUSessionResourceNotifyIEsPresentRANUENGAPID,
+									RANUENGAPID: &ngapType.RANUENGAPID{Value: ranUe.RanUeNgapId},
+								},
+							},
+							{
+								Id: ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDPDUSessionResourceNotifyList},
+								Value: ngapType.PDUSessionResourceNotifyIEsValue{
+									Present:                      ngapType.PDUSessionResourceNotifyIEsPresentPDUSessionResourceNotifyList,
+									PDUSessionResourceNotifyList: &list,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Seven of the sixteen sites recorded the missing context and then handed it to the session
+// management function consumer anyway. Its first act is to read the SMF's URI out of the
+// context, so the nil pointer ended the process - and the AMF's NGAP paths run with no
+// recover(), which means every UE on every gNB, not just this session. The recording is worth
+// little if the AMF does not survive to be scraped.
+func TestNotifyForAnUnresolvableSessionDoesNotEndTheProcess(t *testing.T) {
+	self := context.AMF_Self()
+
+	ran := context.NewAmfRanDefault()
+	ran.AnType = models.ACCESSTYPE__3_GPP_ACCESS
+
+	ranUe, err := ran.NewRanUe(703)
+	if err != nil {
+		t.Fatalf("NewRanUe() = %v", err)
+	}
+	ranUe.Log = logger.NgapLog
+
+	amfUe := self.NewAmfUe("")
+	amfUe.AttachRanUe(ranUe)
+
+	before := unknownSmContextCount(t, "PDUSessionResourceNotify")
+
+	// A panic here fails the test by unwinding it; the assertion below is for the quieter
+	// failure where the session is skipped without being recorded.
+	HandlePDUSessionResourceNotify(ctxt.Background(), ran, notifyNaming(ranUe, 7))
+
+	if got := unknownSmContextCount(t, "PDUSessionResourceNotify") - before; got != 1 {
+		t.Errorf("counter rose by %v for a notify naming one unresolvable session, want 1", got)
+	}
+}


### PR DESCRIPTION
## The condition

Nineteen places in `ngap/handler.go` reach the same state: a RAN message names a PDU session this AMF holds no SM context for. Sixteen of them logged `SmContext[PDU Session ID:%d] not found` — nine then skipped the session and seven did not — and **three said nothing at all**, in `HandleHandoverRequestAcknowledge` (both lists) and `HandleHandoverRequired`, where the lookup sits in an `if exist {…}` with no else. Those three were added to the class during review. In one 1000-UE run on our cluster that line fired 213 times, and nothing outside the log could say which message it was or how many sessions it affected. A RAN with a working tunnel and an SMF with a pending session can both persist that way, unnoticed and unretried.

What the seven did instead is the second commit.

## What this changes

**1. One recorder for the class.** All nineteen sites call `recordUnknownSmContext`, which counts the session in a new counter and names the NGAP message in its only label:

```
amf_ngap_unknown_sm_context_total{message="PDUSessionResourceSetupResponse"}
```

Counting is per session, not per message: a single setup response can name several sessions and only some may be unresolvable, so a per-message counter could not express "two of the sessions in this message were stranded". The label is `message` rather than reusing `ngap_messages_total{msg_type=…}`, whose values are procedure names and cannot tell a `UEContextRelease` from a `UEContextReleaseRequest`.

The recorder deliberately does not try to *resolve* the condition, because neither route is open to the AMF alone:

- The SMF cannot be told. `SendUpdateSmContextN2Info` takes the SM context, and the SMF's URI lives in the very context that is missing.
- Releasing the session towards the RAN is available but not the AMF's to author. `PDU SESSION RESOURCE RELEASE COMMAND` is an AMF-to-RAN message and needs only a `RanUe` and a released list, but TS 38.413 clause 9.2.1.3 carries the PDU Session Resource Release Command Transfer in that message as mandatory, and clause 9.3.4.12 declares that IE transparent to the AMF — the AMF relays one the SMF wrote rather than writing its own.

So the obligation this commit meets is to leave the condition discoverable, and it changes no control flow itself. The seven sites whose flow does change are the next commit, and two more changed during review: the pair in `HandleInitialContextSetupResponse` used `return`, which abandoned not just the remaining sessions in that list but the whole handler including the failed-to-setup list below it, and now `continue`. Two sites are annotated rather than left uniform: `InitialContextSetupFailure` records the condition as expected rather than as a fault, since a failed context setup leaves no established session to reconcile, and the recorder is nil-safe on its `RanUe` because the defect being fixed was itself an unchecked pointer.

**2. Seven of those sites end the process.** `HandlePDUSessionResourceModifyResponse` (both lists), `HandlePDUSessionResourceNotify` (both lists), `HandleHandoverNotify` and `HandlePathSwitchRequest` (both lists) logged the missing context and then passed that **nil** pointer straight into the consumer. `SendUpdateSmContextRequest` reads `smContext.SmfUri()` before it builds anything — into its opening span attributes — and `SmfUri()` takes the context's read lock, so the call is a nil-pointer dereference.

Nothing recovers it. These handlers run on the UE's own event-channel goroutine (`EventChannel.Start` in `context/transaction.go`), which has no `recover()`, and neither does the NGAP reader goroutine that feeds it. One RAN message naming a PDU session this AMF does not know therefore drops every UE on every gNB, not just that session — and it made the counter above nearly useless on those paths, since it incremented and then the process died before anything could scrape it.

Each of the seven now skips the session after recording it. Nothing further in those loop bodies can run without the context anyway: they read a response the consumer never returned. For `HandlePathSwitchRequest` that leaves the session in neither the switched list nor the failed list of the acknowledge, which is exactly where the pre-existing consumer-error path already leaves it; a failed-list item would need a `PathSwitchRequestUnsuccessfulTransfer`, which clause 9.3.4.20 also declares transparent to the AMF.

The same shape exists once outside the NGAP handlers, in `producer/ue_context.go` (`registrationStatusUpdateProcedure`, reached from a peer AMF's registration status update rather than from the RAN, and falling into `SendReleaseSmContextRequest`). It is left for a separate pull request so this one stays about RAN messages.

`VERSION` is left to the release PRs.

## Tests

`ngap/unknown_sm_context_test.go`, driving the handlers rather than the recorder:

- `TestSetupResponseCountsSessionsRatherThanMessages` — one setup response naming two unresolvable sessions raises the counter by exactly 2
- `TestReleaseResponseIdentifiesASessionTheAmfCannotResolve` — the release shape, where the consequence inverts: an SMF still holding a session the RAN has let go
- `TestNotifyForAnUnresolvableSessionDoesNotEndTheProcess` — panics without the skip in the second commit
- `TestRecordUnknownSmContextSurvivesANilRanUe` — the recorder's own nil path

Each was checked against a mutation of the code it covers: counting per message fails the first, reverting the release site to log-and-continue fails the second, removing the notify skip panics the third, and dropping the nil guard panics the fourth.

`HandlePathSwitchRequest`, `HandleHandoverNotify`, `HandleHandoverRequestAcknowledge` and `HandleHandoverRequired` are not driven by a test: they need a valid security context or a prepared handover to reach the site, and their early exits send NGAP messages into an association a unit test does not have. Those sites were read line by line instead — `HandleHandoverNotify` takes `sourceUe` rather than `ranUe`, and one path-switch site's old line wrote `ID: %d` with a space.

## Verification

`pre-commit run --all-files` passes with the repository's own hooks (gitleaks, gci, yamlfmt, end-of-file-fixer, trailing-whitespace, reuse lint). The three Go hooks need Linux SCTP for `ngap/service`, so they were run in the `linux/amd64` `golangci/golangci-lint:v2.13.2` image instead: `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` (13 packages ok) and `golangci-lint run` (0 issues), plus `staticcheck ./...`.

