### PR TITLE
fix(producer): skip a release for a session with no SM context

### DIFF
--- a/producer/ue_context.go
+++ b/producer/ue_context.go
@@ -633,7 +633,13 @@ func registrationStatusUpdateProcedure(ctx ctxt.Context, ueContextID string, ueR
 			}
 			smContext, ok := ue.SmContextFindByPDUSessionID(pduSessionId)
 			if !ok {
-				ue.ProducerLog.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionId)
+				// There is nothing to release, and nothing to release it with: the SMF's URI
+				// lives in the SM context that is missing, and SendReleaseSmContextRequest
+				// reads it before it builds anything. This procedure runs on the UE's
+				// event-channel goroutine, which has no recover, so handing the nil pointer
+				// on would end the process rather than the request.
+				ue.ProducerLog.Errorf("SmContext[PDU Session ID:%d] not found, nothing to release", pduSessionId)
+				continue
 			}
 			problem, err := consumer.SendReleaseSmContextRequest(ue, smContext, causeAll, "", nil)
 			if problem != nil {

--- a/producer/ue_context_transfer_test.go
+++ b/producer/ue_context_transfer_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	ctxt "context"
+	"testing"
+
+	"github.com/omec-project/amf/context"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// A peer AMF completing a UE context transfer names the sessions this AMF should release. It
+// can name one this AMF holds no SM context for - the UE may never have had it, or it may have
+// been released already - and the release consumer reads the SMF's URI out of that context
+// before it builds anything. Since this procedure runs on the UE's event-channel goroutine,
+// which has no recover(), handing it the missing context ended the process rather than the
+// request, taking every other UE with it.
+func TestTransferredReleaseSkipsASessionWithNoSmContext(t *testing.T) {
+	self := context.AMF_Self()
+
+	ue := self.NewAmfUe("imsi-208930100007531")
+	ue.SetGuti("20893cafe0000531")
+	t.Cleanup(ue.Remove)
+
+	// Reaching the assertions at all is the point: without the guard this panics.
+	rsp, problemDetails := registrationStatusUpdateProcedure(ctxt.Background(), "5g-guti-20893cafe0000531",
+		models.UeRegStatusUpdateReqData{
+			TransferStatus:       models.UECONTEXTTRANSFERSTATUS_TRANSFERRED,
+			ToReleaseSessionList: []int32{1},
+		})
+
+	if problemDetails != nil {
+		t.Fatalf("registrationStatusUpdateProcedure() problem details = %+v, want none", problemDetails)
+	}
+
+	if rsp == nil || !rsp.RegStatusTransferComplete {
+		t.Errorf("registrationStatusUpdateProcedure() = %+v, want the transfer reported complete", rsp)
+	}
+}


### PR DESCRIPTION
## The defect

A peer AMF completing a UE context transfer sends `RegistrationStatusUpdate` with `TransferStatus: TRANSFERRED` and `toReleaseSessionList` — the PDU sessions this AMF should release. `registrationStatusUpdateProcedure` looks each one up and carries on whether or not it found anything:

```go
smContext, ok := ue.SmContextFindByPDUSessionID(pduSessionId)
if !ok {
	ue.ProducerLog.Errorf("SmContext[PDU Session ID:%d] not found", pduSessionId)
}
problem, err := consumer.SendReleaseSmContextRequest(ue, smContext, causeAll, "", nil)
```

`SendReleaseSmContextRequest` reads `smContext.SmfUri()` in its first statement block, and `SmfUri()` takes the context's read lock, so with `ok` false that call is a nil-pointer dereference. A peer AMF naming a session this AMF does not hold — because it was released already, or because the UE never had it here — is enough.

## Why it is a dead process rather than a failed request

The procedure does not run on the request goroutine. `HandleRegistrationStatusUpdateRequest` submits an `SbiMsg` to the UE's event channel and blocks on its result:

```go
ue.EventChannel.UpdateSbiHandler(UeContextHandler)
ue.EventChannel.SubmitMessage(sbiMsg)
msg, read := <-sbiMsg.Result
```

`EventChannel.Start` (`context/transaction.go`) is a bare `for`/`select` with no `recover()`, so the panic is not caught by the gin recovery middleware — that covers the HTTP goroutine, which is parked on a channel nothing will ever send to. An unrecovered panic ends the process, so one peer AMF's transfer-completion drops every UE on every gNB.

## The change

Record the condition and skip the session. There is nothing to release and nothing to release it with: the SMF's URI lives in the SM context that is missing, so the release cannot be addressed to anyone. The UE context is still removed at the end of the procedure exactly as before, so nothing else about the transfer changes.

A release that failed against the SMF was already logged without changing the response; a session with no context to release is now answered the same way. Nothing per-session is owed back to the peer either: TS 23.502 clause 5.2.2.2.3 gives `Namf_Communication_RegistrationStatusUpdate` "Output, Required: None", and clause 4.2.2.2.2 step 10 puts the obligation on the old AMF towards the SMF, which is the one call this AMF cannot make without the context.

This is the same shape as the NGAP-side sites in #817, and deliberately not in that pull request: the trigger there is a RAN message, here it is a peer AMF over N14, so they are separate defects with separate reproductions. The counter added there is named for NGAP and would mislabel this path, which is why this commit records the condition in the log alone; it can adopt that recorder once #817 lands.

## Tests

`producer/ue_context_transfer_test.go` drives `registrationStatusUpdateProcedure` directly with a UE that has no SM context and one session named for release. Reaching the assertions is the test: against the previous code it panics with `invalid memory address or nil pointer dereference`, verified by reverting the guard in a copy of the tree.

I swept the rest of the repository for the same shape — every other caller that hands a context from `SmContextFindByPDUSessionID` to a consumer either uses the guarded `if smContext, ok := …; ok {` form (`gmm/handler.go`, three sites), checks the flag before every use, or returns on `!ok`. Outside the NGAP handlers this was the only one that fell through.

## Verification

`pre-commit run --all-files` is clean on darwin with `SKIP=go-test-race,golangci-lint-full,staticcheck` — `ngap/service` needs Linux SCTP, so the module does not build here. Those three ran on linux/amd64 in the `golangci/golangci-lint:v2.13.2` image at the versions `.pre-commit-config.yaml` pins: `golangci-lint run` (0 issues), `staticcheck ./...` v0.8.1 (clean), `go test -race ./... -count=1` (13 packages ok), plus `go build ./...` and `go vet ./...`.
