### PR TITLE
Test shared E2E workflow revision

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,6 @@ jobs:
       checks: write
       id-token: write
       attestations: write
-    uses: omec-project/.github/.github/workflows/e2e-test.yml@f977114a69e50ecb3ac7c334c630136c218f814e # test shared E2E workflow PR #204
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@5c00590a8af523b43b03c3f1c9246afb7fa033b8 # test shared E2E workflow PR #204
     with:
       branch_name: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,6 @@ jobs:
       checks: write
       id-token: write
       attestations: write
-    uses: omec-project/.github/.github/workflows/e2e-test.yml@c6f69e74f8ee9034dcc237ccbd719de59526aee5 # v0.0.30
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@799176c831bc7130b5bd7dd5be79d6af559e0259 # test shared E2E workflow PR #204
     with:
       branch_name: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,6 @@ jobs:
       checks: write
       id-token: write
       attestations: write
-    uses: omec-project/.github/.github/workflows/e2e-test.yml@b48fc19cc6ae880b728d7c1dbed07bb60276ac9a # test shared E2E workflow PR #204
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@f977114a69e50ecb3ac7c334c630136c218f814e # test shared E2E workflow PR #204
     with:
       branch_name: ${{ github.ref }}
-      scripts_ref: b48fc19cc6ae880b728d7c1dbed07bb60276ac9a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
       checks: write
       id-token: write
       attestations: write
-    uses: omec-project/.github/.github/workflows/e2e-test.yml@799176c831bc7130b5bd7dd5be79d6af559e0259 # test shared E2E workflow PR #204
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@b48fc19cc6ae880b728d7c1dbed07bb60276ac9a # test shared E2E workflow PR #204
     with:
       branch_name: ${{ github.ref }}
+      scripts_ref: b48fc19cc6ae880b728d7c1dbed07bb60276ac9a


### PR DESCRIPTION
## Purpose

Validate the current single-image AMF E2E path against the proposed shared E2E workflow implementation in omec-project/.github#204.

This changes only the `e2e-test.yml` reference to commit `799176c831bc7130b5bd7dd5be79d6af559e0259`; all AMF inputs and workflow behavior remain unchanged.

A successful `e2e-tests` run is the backward-compatibility acceptance test for the shared workflow. This temporary PR should not be merged.